### PR TITLE
Fix object relation browse mode class constraint list when no classes are selected

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -437,7 +437,11 @@ class eZObjectRelationType extends eZDataType
                 {
                     $classConstraintList = array();
                 }
-                $browseParameters['class_array'] = $classConstraintList;
+
+                if ( count($classConstraintList) > 0 )
+                {
+                    $browseParameters['class_array'] = $classConstraintList;
+                }
 
                 eZContentBrowse::browse( $browseParameters,
                                          $module );


### PR DESCRIPTION
Shouldn't send the class constraint list if no classes are selected