### PR TITLE
Apply ezjscore DDOS patch to limit the number of fetched nodes

### DIFF
--- a/extension/ezjscore/classes/ezjscserverfunctionsnode.php
+++ b/extension/ezjscore/classes/ezjscserverfunctionsnode.php
@@ -64,6 +64,14 @@ class ezjscServerFunctionsNode extends ezjscServerFunctions
             throw new ezcBaseFunctionalityNotSupportedException( 'Fetch node list', "Parent node '$parentNodeID' is not valid" );
         }
 
+        $ezjscoreIni = eZINI::instance( 'ezjscore.ini' );
+        $hardLimit = (int)$ezjscoreIni->variable( 'ezjscServer_ezjscnode', 'HardLimit' );
+
+        if ( $hardLimit > 0 && $limit > $hardLimit )
+        {
+            $limit = $hardLimit;
+        }
+        
         $params = array( 'Depth' => 1,
                          'Limit' => $limit,
                          'Offset' => $offset,

--- a/extension/ezjscore/settings/ezjscore.ini
+++ b/extension/ezjscore/settings/ezjscore.ini
@@ -116,6 +116,13 @@ Class=ezjscServerFunctionsJs
 Class=ezjscServerFunctionsNode
 #File=extension/ezjscore/classes/ezjscserverfunctionsnode.php
 
+# Allows setting a Hard Limit to the subtree method to prevent the load of very large subtrees
+#  reducing server load and risk of DOS attacks.
+#  false disables the feature, any integer will set the hard limit.
+#  for example: a hard limit of 100 will allow limiting to 30 or 40, but will replace a
+#               limit of 150.
+HardLimit=100
+
 [ezjscServer_ezjsctemplate]
 # Url to test this server function(return alert message):
 # <root>/ezjscore/call/ezjsctemplate::alert


### PR DESCRIPTION
Instead of a default of HardLimit=false, use HardLimit=100 so that we don't rely on developers to always set this limit in an override of ezsjcore.ini.append.php