### PR TITLE
Making sure the tables do not fully collapse on IE

### DIFF
--- a/extension/ezoe/design/standard/stylesheets/skins/default/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/default/content.css
@@ -44,6 +44,7 @@ h6
 }
 
 .mceItemTable, .mceItemTable td, .mceItemTable th, .mceItemTable caption, .mceItemVisualAid {border: 1px dashed #BBB;}
+.mceItemTable td { min-height: 20px; }
 a.mceItemAnchor {display:inline-block; -webkit-user-select:all; -webkit-user-modify:read-only; -moz-user-select:all; -moz-user-modify:read-only; width:11px !important; height:11px  !important; background:url(img/items.gif) no-repeat center center}
 span.mceItemNbsp {background: #DDD}
 td.mceSelected, th.mceSelected {background-color:#3399ff !important}

--- a/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
@@ -43,6 +43,7 @@ h6
 }
 
 .mceItemTable, .mceItemTable td, .mceItemTable th, .mceItemTable caption, .mceItemVisualAid {border: 1px dashed #BBB;}
+.mceItemTable td { min-height: 20px; }
 a.mceItemAnchor {display:inline-block; width:11px !important; height:11px  !important; background:url(../default/img/items.gif) no-repeat 0 0;}
 span.mceItemNbsp {background: #DDD}
 td.mceSelected, th.mceSelected {background-color:#3399ff !important}


### PR DESCRIPTION
It fixes an issue in IE. If you insert a table into a ezxmltext attribute, in IE all table cells are collapsed making it hard to select a specific cell. With this patch each cell should be at least 20px high.
