### PR TITLE
commandURLCleanup now strips all unwanted chars at the end of the string

### DIFF
--- a/lib/ezi18n/classes/ezchartransform.php
+++ b/lib/ezi18n/classes/ezchartransform.php
@@ -395,12 +395,10 @@ class eZCharTransform
         $sep  = eZCharTransform::wordSeparator();
         $sepQ = preg_quote( $sep );
         $text = preg_replace( array( "#[^a-zA-Z0-9_!\.-]+#",
-                                     "#^[\.]+|[!\.]+$#", # Remove dots at beginning/end
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
-                                     "#^[{$sepQ}]+|[{$sepQ}]+$#" ), # Strip separator from beginning/end
+                                     "#^[{$sepQ}\.]+|[{$sepQ}!\.]+$#" ), # Strip unwanted chars from beginning/end
                               array( $sep,
-                                     $sep,
                                      $sep,
                                      $sep,
                                      "" ),

--- a/lib/ezi18n/classes/ezchartransform.php
+++ b/lib/ezi18n/classes/ezchartransform.php
@@ -397,7 +397,7 @@ class eZCharTransform
         $text = preg_replace( array( "#[^a-zA-Z0-9_!\.-]+#",
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
-                                     "#^[{$sepQ}\.]+|[{$sepQ}!\.]+$#" ), # Strip unwanted chars from beginning/end
+                                     "#^[{$sepQ}\.]+|[{$sepQ}!\.]+$#" ), # Strip separator and dot from beginning, strip exclemation mark, dot and separator from end
                               array( $sep,
                                      $sep,
                                      $sep,

--- a/lib/ezi18n/classes/ezchartransform.php
+++ b/lib/ezi18n/classes/ezchartransform.php
@@ -410,7 +410,7 @@ class eZCharTransform
     {
         // With IRI support we keep all characters except some reserved ones,
         // they are space, tab, ampersand, semi-colon, forward slash, colon, equal sign, question mark,
-        //          square brackets, parenthesis, plus.
+        //          square brackets, parenthesis, plus, double quote.
         //
         // Note: Spaces and tabs are turned into a dash to make it easier for people to
         //       paste urls from the system and have the whole url recognized
@@ -420,13 +420,11 @@ class eZCharTransform
         $prepost = " ." . $sepQ;
         if ( $sep != "-" )
             $prepost .= "-";
-        $text = preg_replace( array( "#[ \t\\\\%\#&;/:=?\[\]()+]+#",
-                                     "#^[\.]+|[!\.]+$#", # Remove dots at beginning/end
+        $text = preg_replace( array( "#[ \t\\\\%\#&;/:=?\[\]()+\"]+#",
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
-                                     "#^[{$prepost}]+|[{$prepost}]+$#" ),
+                                     "#^[{$prepost}]+|[!{$prepost}]+$#" ), # Strip "!", dots and separator from beginning/end
                               array( $sep,
-                                     $sep,
                                      $sep,
                                      $sep,
                                      "" ),

--- a/lib/ezi18n/classes/ezchartransform.php
+++ b/lib/ezi18n/classes/ezchartransform.php
@@ -397,7 +397,7 @@ class eZCharTransform
         $text = preg_replace( array( "#[^a-zA-Z0-9_!\.-]+#",
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
-                                     "#^[{$sepQ}\.]+|[{$sepQ}!\.]+$#" ), # Strip separator and dot from beginning, strip exclemation mark, dot and separator from end
+                                     "#^[{$sepQ}\.]+|[{$sepQ}!\.]+$#" ), # Strip separator and dot from beginning, strip exclamation mark, dot and separator from end
                               array( $sep,
                                      $sep,
                                      $sep,

--- a/tests/tests/lib/ezi18n/ezchartransform_test.php
+++ b/tests/tests/lib/ezi18n/ezchartransform_test.php
@@ -38,4 +38,15 @@ class eZCharTransformTests extends ezpTestCase
         $transformed = eZCharTransform::commandUrlCleanup( $objectName );
         $this->assertEquals( $transformed, 'test' );
     }
+
+    public function testCommandUrlCleanupIRI()
+    {
+        $objectName = '.täst."';
+        $transformed = eZCharTransform::commandUrlCleanupIRI( $objectName );
+        $this->assertEquals( 'täst', $transformed );
+
+        $objectName = '.test!"';
+        $transformed = eZCharTransform::commandUrlCleanupIRI( $objectName );
+        $this->assertEquals( 'test', $transformed );
+    }
 }

--- a/tests/tests/lib/ezi18n/ezchartransform_test.php
+++ b/tests/tests/lib/ezi18n/ezchartransform_test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * File containing the eZCharTransFormTests class
+ *
+ * @package tests
+ */
+
+class eZCharTransFormTests extends ezpTestCase
+{
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setName( "eZCharTransFormTests" );
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    public function testCommandUrlCleanupMultipleSpecialCharsAtEnd()
+    {
+        $objectName = 'test."';
+        $transformed = eZCharTransform::commandUrlCleanup( $objectName );
+        $this->assertEquals( $transformed, 'test' );
+
+        $objectName = 'te.st."';
+        $transformed = eZCharTransform::commandUrlCleanup( $objectName );
+        $this->assertEquals( $transformed, 'te.st' );
+
+        $objectName = '.test!"';
+        $transformed = eZCharTransform::commandUrlCleanup( $objectName );
+        $this->assertEquals( $transformed, 'test' );
+    }
+}

--- a/tests/tests/lib/ezi18n/ezchartransform_test.php
+++ b/tests/tests/lib/ezi18n/ezchartransform_test.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * File containing the eZCharTransFormTests class
+ * File containing the eZCharTransformTests class
  *
  * @package tests
  */
 
-class eZCharTransFormTests extends ezpTestCase
+class eZCharTransformTests extends ezpTestCase
 {
 
     public function __construct()
     {
         parent::__construct();
-        $this->setName( "eZCharTransFormTests" );
+        $this->setName( "eZCharTransformTests" );
     }
 
     public function setUp()

--- a/tests/tests/lib/ezi18n/suite.php
+++ b/tests/tests/lib/ezi18n/suite.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File containing the eZFileTestSuite class
+ *
+ * @package tests
+ */
+
+class eZFileTestSuite extends ezpTestSuite
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setName( "eZFile Test Suite" );
+        $this->addTestSuite( 'eZCharTransFormTests' );
+    }
+
+    public static function suite()
+    {
+        return new self();
+    }
+
+}

--- a/tests/tests/lib/ezi18n/suite.php
+++ b/tests/tests/lib/ezi18n/suite.php
@@ -5,7 +5,7 @@
  * @package tests
  */
 
-class eZFileTestSuite extends ezpTestSuite
+class eZCharTransformTestSuite extends ezpTestSuite
 {
     public function __construct()
     {

--- a/tests/tests/lib/ezi18n/suite.php
+++ b/tests/tests/lib/ezi18n/suite.php
@@ -11,7 +11,7 @@ class eZFileTestSuite extends ezpTestSuite
     {
         parent::__construct();
         $this->setName( "eZFile Test Suite" );
-        $this->addTestSuite( 'eZCharTransFormTests' );
+        $this->addTestSuite( 'eZCharTransformTests' );
     }
 
     public static function suite()


### PR DESCRIPTION
This came up in the CSM project: ticket 3479.

If you have an object name like "about." (including the double quotes), ezp was not removing the dot after 'about'.
