### PR TITLE
Fix EZP-26354: Autolink fails if you try to link content in your own site

### DIFF
--- a/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
+++ b/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
@@ -423,8 +423,10 @@
                     var currenthost = document.location.protocol + '//' + document.location.host;
                     jQuery.each( body.getElementsByTagName('a'), function( i, node )
                     {
-                        if ( node.href.indexOf( currenthost ) === 0 && node.getAttribute('data-mce-href') != node.href )
-                            node.href = node.getAttribute('data-mce-href');
+                        var mceHref = node.getAttribute('data-mce-href');
+
+                        if ( node.href.indexOf( currenthost ) === 0 && mceHref && mceHref != node.href )
+                            node.href = mceHref;
                     });
                 }
             });


### PR DESCRIPTION
Original pull request: https://github.com/ezsystems/ezpublish-legacy/pull/1263

JIRA: https://jira.ez.no/browse/EZP-26354

Description

In OE, when an URL is recognized, a link is automatically created. This is done by the autolink TinyMCE plugin but the markup generated is a bit different than the one generated by the regular insert link tool. Mainly it does not add the data-mce-href attribute. Unfortunately, this attribute is expected by some code added to work around an IE bug. So this patch improves the workaround so that it won't break links without the data-mce-href attribute.

Tests

manual tests (including in IE8)
