### PR TITLE
generateNodeViewData is also setting the DesignKey "layout"

### DIFF
--- a/kernel/classes/eznodeviewfunctions.php
+++ b/kernel/classes/eznodeviewfunctions.php
@@ -77,6 +77,10 @@ class eZNodeviewfunctions
                                           array $viewParameters = array( 'offset' => 0, 'year' => false, 'month' => false, 'day' => false ),
                                           $collectionAttributes = false, $validation = false )
     {
+        // Build DesignKeys
+        $res = eZTemplateDesignResource::instance();
+        $res->setKeyValue( 'layout', '', false );
+
         $section = eZSection::fetch( $object->attribute( 'section_id' ) );
         if ( $section )
         {
@@ -135,7 +139,6 @@ class eZNodeviewfunctions
             }
         }
 
-        $res = eZTemplateDesignResource::instance();
         $res->setKeys( $keyArray );
 
         if ( $languageCode )

--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -8,12 +8,12 @@
  * @package kernel
  */
 
-/*!
-  \class eZTemplatedesignresource eztemplatedesignresource.php
-  \brief Handles template file loading with override support
-
-*/
-
+/**
+ * Class eZTemplateDesignResource
+ * Handles template file loading with override support
+ *
+ * @package kernel
+ */
 class eZTemplateDesignResource extends eZTemplateFileResource
 {
     const DESIGN_BASE_CACHE_NAME = 'designbase_';
@@ -952,6 +952,27 @@ class eZTemplateDesignResource extends eZTemplateFileResource
     function setKeys( $keys )
     {
         $this->mergeKeys( $this->Keys, $keys );
+    }
+
+    /**
+     * Sets a single key value. By default the value is overwritten unless $override
+     * is set to false
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param bool $override
+     * @return $this
+     */
+    public function setKeyValue( $key, $value, $override = true )
+    {
+        if( !$override )
+        {
+            $value = isset( $this->Keys[ $key ] ) ? $this->Keys[ $key ] : $value;
+        }
+
+        $this->Keys[ $key ] = $value;
+
+        return $this;
     }
 
     /*!


### PR DESCRIPTION
**Reason for this pull request:**
In the CSM project we have various output formats based on object state and also layout (_/layout/set/_). We run into problems specifying the template override rules because we cannot match against an "empty" (a non-layout view) layout. With this patch you will be able to specify an override rule like this:

```
[full_article]
Source=node/view/full.tpl
MatchFile=full/article.tpl
Subdir=templates
Match[class_identifier]=article
#Matching an non layout view
Match[layout]=
```

**Technical implementation:**
The full view (and the preview view) is using the method _generateNoveViewData_ to build the _DesignKeys_. The _DesignKeys_ is an array of values that can be used for the override rules - usually you have something like:

```
node_id,
section_id,
class_identifier,
```

etc

In this function the new code is adding the _layout_ key to this array.

`$res->setKeyValue( 'layout', '', false );`

The last parameter of this function specifies if you like to override the key if it exists. In our case we don't want to override the key because the module-view layout/set might have set the key already.

**Background Info:**
The class _eZTemplateDesignResource_ is responsible to collect the _DesignKeys_ (it's a singleton). So in the module-view layout/set is can set the _DesiginKey_ called _layout_. Then the this module-view is executing the normal module-view content/view -- content/view is then setting additional _DesignKey_.
This patch is setting (but not overwriting) the key _layout_ in context of content/view and content/versionview.

For the override rules (see example from above), you are not able to match on a non-existing _DesignKey_. So

`Match[layout]=`

is only working if you set the _DesignKey_ _layout_ to an empty string.

I added the function _ setKeyValue_ to the _eZTemplateDesignResource_ class because I think it's useful also in other instances. We could replace existing code like this:

`$res->setKeys( array( array( 'layout', $LayoutStyle ) ) );`

I replaced some old inline comments to proper PHPDOC.
