### PR TITLE
Fix EZP-26427: ezoe popup search string not urlencoded

### DIFF
--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -745,7 +745,7 @@ var eZOEPopupUtils = {
         var postData = '', val;
         jQuery.each( jQuery('#' + id + ' input, #' + id + ' select').serializeArray(), function(i, o){
             if ( o.value )
-                postData += ( postData ? '&' : '') + o.name + '=' + o.value;
+                postData += ( postData ? '&' : '') + o.name + '=' + encodeURIComponent(o.value);
         });
         return postData;
     },


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26427

Problem:

eZOE popup utils does not urlencode form parameters, which can result in query strings being broken/ incorrectly split (eg: some&string => /call?SearchStr=some&string& ... )

ORIGINAL PULL REQUEST:
https://github.com/ezsystems/ezpublish-legacy/pull/1264
