### PR TITLE
Enable audit log by default

### DIFF
--- a/settings/audit.ini
+++ b/settings/audit.ini
@@ -14,7 +14,7 @@
 # Since 4.7, LogDir is relative to var/{site.ini/[FileSettings]/VarDir} setting
 LogDir=log/audit
 # If 'enabled' the possibility will be enabled.
-Audit=disabled
+Audit=enabled
 
 # Audit file names setting.
 # The key of AuditFileNames[] is the name of audit and value is file name.


### PR DESCRIPTION
* We eventually enable the audit log for most clients
* The audit log usually gets enabled after something bad has happened (and at that point we waste a bunch of time trying to analyze the Apache logs)
* There are only positives to having the audit log enabled
* The log files automatically rotate, so there isn't additional configuration that we need to remember