### PR TITLE
Function normalizedVarExport fixed due to new minor PHP release

### DIFF
--- a/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
+++ b/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
@@ -83,7 +83,10 @@ class ezpRestHttpRequestParserRegression extends ezpRegressionTest
     private static function normalizedVarExport( $var )
     {
         $var = var_export( $var, true );
-        if ( PHP_VERSION_ID <= 50509 )
+        // 50505 is PHP 5.5.5
+        // 50509 is PHP 5.5.9
+        // version from 50505 to 50509 are also affected
+        if ( PHP_VERSION_ID <= 50430 || ( PHP_VERSION_ID >= 50505 && PHP_VERSION_ID <= 50509 ) )
         {
             $var = preg_replace( '%(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})%', '$1.000000', $var );
         }

--- a/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
+++ b/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
@@ -83,7 +83,7 @@ class ezpRestHttpRequestParserRegression extends ezpRegressionTest
     private static function normalizedVarExport( $var )
     {
         $var = var_export( $var, true );
-        if ( PHP_VERSION_ID < 50430 )
+        if ( PHP_VERSION_ID <= 50509 )
         {
             $var = preg_replace( '%(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})%', '$1.000000', $var );
         }

--- a/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
+++ b/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
@@ -85,8 +85,8 @@ class ezpRestHttpRequestParserRegression extends ezpRegressionTest
         $var = var_export( $var, true );
         // 50505 is PHP 5.5.5
         // 50509 is PHP 5.5.9
-        // version from 50505 to 50509 are also affected
-        if ( PHP_VERSION_ID <= 50430 || ( PHP_VERSION_ID >= 50505 && PHP_VERSION_ID <= 50509 ) )
+        // version from 50500 to 50513 are also affected
+        if ( PHP_VERSION_ID < 50430 || ( PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50514 ) )
         {
             $var = preg_replace( '%(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})%', '$1.000000', $var );
         }

--- a/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
+++ b/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
@@ -83,8 +83,7 @@ class ezpRestHttpRequestParserRegression extends ezpRegressionTest
     private static function normalizedVarExport( $var )
     {
         $var = var_export( $var, true );
-        // 50505 is PHP 5.5.5
-        // 50509 is PHP 5.5.9
+        // 50430 is PHP 5.4.30
         // version from 50500 to 50513 are also affected
         if ( PHP_VERSION_ID < 50430 || ( PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50514 ) )
         {


### PR DESCRIPTION
Since PHP 5.4.30, DateTime are not serialized the same way as previous versions.
See http://php.net/ChangeLog-5.php#5.4.30 & https://bugs.php.net/bug.php?id=67308

The function is not working correctly for new minor PHP versions. I had to increase the version ID. There is a chance we have to do it again for future minor PHP versions.

The string presentation for datetime in old PHP versions is:
1479223611
In new versions it is:
1479223611.000000

