### PR TITLE
Better error message if an operator has no default value for a parameter

### DIFF
--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -1316,12 +1316,20 @@ class eZTemplate
                     if ( !$checkExistance )
                         $this->warning( "eZTemplateOperatorElement", "Parameter '$parameterName' ($i) missing",
                                         $placement );
-                    $namedParameters[$parameterName] = $parameterType["default"];
                 }
-                else
+
+                if( !isset( $parameterType[ 'default' ] ) )
                 {
-                    $namedParameters[$parameterName] = $parameterType["default"];
+                    $this->warning(
+                        'eZTemplateOperatorElement',
+                        "Operator '$operatorName' has no default value for the parameter '$parameterName' ($i) ",
+                        $placement
+                    );
+
+                    $parameterType[ 'default' ] = null;
                 }
+
+                $namedParameters[$parameterName] = $parameterType[ 'default' ];
             }
             else
             {


### PR DESCRIPTION
Here is a good example of an operator definition:

```
'json_encode' => array(
    'hash' => array( 
        'type' => 'hash',
        'required' => true,
        'default' => array()
    )
)
```

A bad example would miss the `'default' => array()` part. In that case ezp shows a warning in the debug output:

_Undefined index: default in /var/www/www.csmonitor.com/lib/eztemplate/classes/eztemplate.php on line 1327_

That's not very useful. With this patch, the debug output will create a warning instead. Here is an example text:

_Operator 'json_encode' has no default value for the parameter 'hash' (0)_
