### PR TITLE
Unit test db setup

### DIFF
--- a/tests/toolkit/ezpdatabasesuite.php
+++ b/tests/toolkit/ezpdatabasesuite.php
@@ -42,27 +42,27 @@ class ezpDatabaseTestSuite extends ezpTestSuite
         $this->setDatabaseEnv();
     }
 
-	/**
-	 * Sets up the database environment
-	 */
+    /**
+     * Sets up the database environment
+     */
     protected function setDatabaseEnv()
     {
-		if ( !ezpTestRunner::dbPerTest() && !self::$isDatabaseSetup )
-		{
-			$dsn = ezpTestRunner::dsn();
-			$this->sharedFixture = ezpTestDatabaseHelper::create( $dsn );
+        if ( !ezpTestRunner::dbPerTest() && !self::$isDatabaseSetup )
+        {
+            $dsn = ezpTestRunner::dsn();
+            $this->sharedFixture = ezpTestDatabaseHelper::create( $dsn );
 
-			if ( $this->insertDefaultData === true )
-				ezpTestDatabaseHelper::insertDefaultData( $this->sharedFixture );
+            if ( $this->insertDefaultData === true )
+                ezpTestDatabaseHelper::insertDefaultData( $this->sharedFixture );
 
-			if ( count( $this->sqlFiles ) > 0 )
-			{
-				ezpTestDatabaseHelper::insertSqlData( $this->sharedFixture, $this->sqlFiles );
-			}
+            if ( count( $this->sqlFiles ) > 0 )
+            {
+                ezpTestDatabaseHelper::insertSqlData( $this->sharedFixture, $this->sqlFiles );
+            }
 
-			eZDB::setInstance( $this->sharedFixture );
-			self::$isDatabaseSetup = true;
-		}
+            eZDB::setInstance( $this->sharedFixture );
+            self::$isDatabaseSetup = true;
+        }
     }
 }
 

--- a/tests/toolkit/ezpdatabasesuite.php
+++ b/tests/toolkit/ezpdatabasesuite.php
@@ -37,27 +37,33 @@ class ezpDatabaseTestSuite extends ezpTestSuite
      */
     protected static $isDatabaseSetup = false;
 
-    /**
-     * Sets up the database environment
-     */
     protected function setUp()
     {
-        if ( !ezpTestRunner::dbPerTest() && !self::$isDatabaseSetup )
-        {
-            $dsn = ezpTestRunner::dsn();
-            $this->sharedFixture = ezpTestDatabaseHelper::create( $dsn );
+        $this->setDatabaseEnv();
+    }
 
-            if ( $this->insertDefaultData === true )
-                ezpTestDatabaseHelper::insertDefaultData( $this->sharedFixture );
+	/**
+	 * Sets up the database environment
+	 */
+    protected function setDatabaseEnv()
+    {
+		if ( !ezpTestRunner::dbPerTest() && !self::$isDatabaseSetup )
+		{
+			$dsn = ezpTestRunner::dsn();
+			$this->sharedFixture = ezpTestDatabaseHelper::create( $dsn );
 
-            if ( count( $this->sqlFiles ) > 0 )
-            {
-                ezpTestDatabaseHelper::insertSqlData( $this->sharedFixture, $this->sqlFiles );
-            }
+			if ( $this->insertDefaultData === true )
+				ezpTestDatabaseHelper::insertDefaultData( $this->sharedFixture );
 
-            eZDB::setInstance( $this->sharedFixture );
-            self::$isDatabaseSetup = true;
-        }
+			if ( count( $this->sqlFiles ) > 0 )
+			{
+				ezpTestDatabaseHelper::insertSqlData( $this->sharedFixture, $this->sqlFiles );
+			}
+
+			eZDB::setInstance( $this->sharedFixture );
+			self::$isDatabaseSetup = true;
+		}
     }
 }
+
 ?>


### PR DESCRIPTION
_ezpDatabaseTestSuite_ is the parent class for a lot of test classes that need a DB connection. In the _setUp()_, it is setting the DB environment. This patch is simply moving that logic into a dedicated PHP function  _setDatabaseEnv()_. In _setUp()_ it's just calling the function - so basically no changes in the logic, just the code organisation changed.

Why is that even worth doing?

Normally, you can write a single test in a single test function. But you can also use PHPUnit Data Providers - it's splitting the test into 2 functions:
https://phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers

The unit test in the ezfind extension are using that approach. There is a problem with the order of how the PHPUnit framework calls the functions:

1) Calls _provider_ function
2) Calls setUp()
3) Calls _test_ functions

Because of that order we don't have a valid DB connection when the _provider_ functions are getting executed. The missing DB connection causes those _provider_ function to throw a deprecated error - it's not a big deal, but it would be much cleaner if the provider functions would have a valid DB connection. The error message:

`PHP Deprecated:  mysql_escape_string(): This function is deprecated; use mysql_real_escape_string() instead. in /var/www/ezp/lib/ezdb/classes/ezmysqlidb.php on line 844`

With this patch, I can implement a simple solution for the ezfind unit tests. I can the _setDatabaseEnv()_ in the constructor method of the test and not wait for _setUp()_ function. That way I already have a valid DB connection when the _provider_ functions are getting executed.