### PR TITLE
New fetch function to access eZSiteData in templates

### DIFF
--- a/kernel/classes/ezsitedata.php
+++ b/kernel/classes/ezsitedata.php
@@ -49,7 +49,7 @@ class eZSiteData extends eZPersistentObject
      * Constructs a new eZSiteData instance. You need to call 'store()'
      * in order to store it into the DB.
      *
-     * @param string $key
+     * @param string $name
      * @param string $value
      * @return eZSiteData
      */
@@ -63,14 +63,13 @@ class eZSiteData extends eZPersistentObject
 
     /**
      * Fetches a site data by name
-	 *
+     *
      * @param string $name
-     * @return eZPersistentObject
+     * @return eZSiteData
      */
     public static function fetchByName( $name )
     {
-        $result = parent::fetchObject( self::definition(), null, array( 'name' => $name ) );
-        return $result;
+        return parent::fetchObject( self::definition(), null, array( 'name' => $name ) );
     }
 
 }

--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -1534,6 +1534,17 @@ class eZContentFunctionCollection
 
         return array( 'result' => $expiryHandler->timestamp( 'content-tree-menu' ) );
     }
+
+    /**
+     * Fetches an eZSiteData instance if it exists in the database.
+     *
+     * @param string $name
+     * @return array
+     */
+    static public function fetchSiteData( $name )
+    {
+        return array( 'result' => eZSiteData::fetchByName( $name ) );
+    }
 }
 
 ?>

--- a/kernel/content/function_definition.php
+++ b/kernel/content/function_definition.php
@@ -1222,21 +1222,13 @@ $FunctionList['content_tree_menu_expiry'] = array( 'name' => 'content_tree_menu_
                                                    'parameter_type' => 'standard',
                                                    'parameters' => array() );
 
-$FunctionList[ 'site_data' ] = array(
-    'name' => 'site_data',
-    'operation_types' => array( 'read' ),
-    'call_method' => array(
-        'class' => 'eZContentFunctionCollection',
-        'method' => 'fetchSiteData'
-    ),
-    'parameter_type' => 'standard',
-    'parameters' => array(
-        array(
-            'name' => 'name',
-            'type' => 'string',
-            'required' => true
-        )
-    )
-);
+$FunctionList[ 'site_data' ] = array( 'name' => 'site_data',
+                                      'operation_types' => array( 'read' ),
+                                      'call_method' => array( 'class' => 'eZContentFunctionCollection',
+                                                              'method' => 'fetchSiteData' ),
+                                      'parameter_type' => 'standard',
+                                      'parameters' => array( array( 'name' => 'name',
+                                                                    'type' => 'string',
+                                                                    'required' => true ) ) );
 
 ?>

--- a/kernel/content/function_definition.php
+++ b/kernel/content/function_definition.php
@@ -1222,4 +1222,21 @@ $FunctionList['content_tree_menu_expiry'] = array( 'name' => 'content_tree_menu_
                                                    'parameter_type' => 'standard',
                                                    'parameters' => array() );
 
+$FunctionList[ 'site_data' ] = array(
+    'name' => 'site_data',
+    'operation_types' => array( 'read' ),
+    'call_method' => array(
+        'class' => 'eZContentFunctionCollection',
+        'method' => 'fetchSiteData'
+    ),
+    'parameter_type' => 'standard',
+    'parameters' => array(
+        array(
+            'name' => 'name',
+            'type' => 'string',
+            'required' => true
+        )
+    )
+);
+
 ?>

--- a/kernel/content/function_definition.php
+++ b/kernel/content/function_definition.php
@@ -1222,13 +1222,13 @@ $FunctionList['content_tree_menu_expiry'] = array( 'name' => 'content_tree_menu_
                                                    'parameter_type' => 'standard',
                                                    'parameters' => array() );
 
-$FunctionList[ 'site_data' ] = array( 'name' => 'site_data',
-                                      'operation_types' => array( 'read' ),
-                                      'call_method' => array( 'class' => 'eZContentFunctionCollection',
-                                                              'method' => 'fetchSiteData' ),
-                                      'parameter_type' => 'standard',
-                                      'parameters' => array( array( 'name' => 'name',
-                                                                    'type' => 'string',
-                                                                    'required' => true ) ) );
+$FunctionList['site_data'] = array( 'name' => 'site_data',
+                                    'operation_types' => array( 'read' ),
+                                    'call_method' => array( 'class' => 'eZContentFunctionCollection',
+                                                            'method' => 'fetchSiteData' ),
+                                    'parameter_type' => 'standard',
+                                    'parameters' => array( array( 'name' => 'name',
+                                                                  'type' => 'string',
+                                                                  'required' => true ) ) );
 
 ?>


### PR DESCRIPTION
New fetch function allows template developers to fetch content from the ezsite_data table. Here is an example:

{fetch( 'content', 'site_data', hash( 'name', 'ezpublish-version' ) )|dump()}

