### PR TITLE
Add location addition, removal, and change of main location to the audit log

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -809,7 +809,11 @@ class eZContentOperationCollection
         }
         if ( $locationAdded )
         {
-
+            eZAudit::writeAudit( 'location-assign', array( 'Main Node ID' => $object->attribute( 'main_node_id' ),
+                                                           'Content object ID' => $object->attribute( 'id' ),
+                                                           'Content object name' => $object->attribute( 'name' ),
+                                                           'New Locations Parent Node ID Array' => implode( ', ' , $selectedNodeIDArray ),
+                                                           'Comment' => 'Assigned new locations to the current node: eZContentOperationCollection::addAssignment()' ) );
             //call appropriate method from search engine
             eZSearch::addNodeAssignment( $nodeID, $objectID, $selectedNodeIDArray );
 
@@ -860,6 +864,13 @@ class eZContentOperationCollection
                 }
             }
 
+            eZAudit::writeAudit( 'location-remove', array( 'Removed Node ID' => $nodeId,
+                                                           'Parent Node ID' => $node->attribute( 'parent_node_id' ),
+                                                           'Content object ID' => $objectId,
+                                                           'Content object name' => $node->attribute( 'name' ),
+                                                           'Was main node' => ( $nodeId == $node->attribute( 'main_node_id' ) ? 'Yes' : 'No' )
+            ) );
+
             if ( $nodeId == $node->attribute( 'main_node_id' ) )
                 $mainNodeChanged[$objectId] = 1;
             $node->removeThis();
@@ -877,6 +888,11 @@ class eZContentOperationCollection
             if ( isset( $allNodes[0] ) )
             {
                 $mainNodeChanged[$objectId] = $allNodes[0];
+                eZAudit::writeAudit( 'main-node-update', array( 'Content object ID' => $objectId,
+                                                                'New Main Node ID' => $allNodes[0]->attribute( 'node_id' ),
+                                                                'New Parent Node ID' => $allNodes[0]->attribute( 'parent_node_id' ),
+                                                                'Comment' => 'Updated the main location of the current object: eZContentOperationCollection::removeNodes()' )
+                );
                 eZContentObjectTreeNode::updateMainNodeID( $allNodes[0]->attribute( 'node_id' ), $objectId, false, $allNodes[0]->attribute( 'parent_node_id' ) );
             }
         }
@@ -1244,6 +1260,11 @@ class eZContentOperationCollection
      */
     static public function updateMainAssignment( $mainAssignmentID, $ObjectID, $mainAssignmentParentID )
     {
+        eZAudit::writeAudit( 'main-node-update', array( 'Content object ID' => $ObjectID,
+                                                        'New Main Node ID' => $mainAssignmentID,
+                                                        'New Parent Node ID' => $mainAssignmentParentID,
+                                                        'Comment' => 'Updated the main location of the current object: eZContentOperationCollection::updateMainAssignment'
+        ) );
         eZContentObjectTreeNode::updateMainNodeID( $mainAssignmentID, $ObjectID, false, $mainAssignmentParentID );
         eZContentCacheManager::clearContentCacheIfNeeded( $ObjectID );
         eZContentOperationCollection::registerSearchObject( $ObjectID );

--- a/settings/audit.ini
+++ b/settings/audit.ini
@@ -50,3 +50,11 @@ AuditFileNames[section-assign]=section_assign.log
 # Who deleted which order in shop (user / order id)
 AuditFileNames[order-delete]=order_delete.log
 
+# Who assigned new locations to a node
+AuditFileNames[location-assign]=location_assign.log
+
+# Who removed a location of a node
+AuditFileNames[location-remove]=location_remove.log
+
+# Who updated the main node
+AuditFileNames[main-node-update]=location_main_update.log


### PR DESCRIPTION
Content move is covered by the audit log, but these actions don't appear to be:
Add a location
Remove a location (but not remove the object)
Change the main location

Knowing who performed these actions could help troubleshoot issues 