### PR TITLE
Allow to set response headers on error pages

### DIFF
--- a/kernel/error/view.php
+++ b/kernel/error/view.php
@@ -66,31 +66,30 @@ $GLOBALS["eZRequestError"] = true;
             {
                 $httpErrorCode = $errorMap[$errorNumber];
 
-                if ( $errorINI->hasVariable( 'HTTPError-' . $httpErrorCode, 'HeaderList' ) )
+                $headers = kernelErrorGetHeaderList( $errorINI, $httpErrorCode );
+
+                if( !empty( $headers ) )
                 {
-                    if( !empty( $errorINI->variable( 'HTTPError-' . $httpErrorCode, 'HeaderList' ) ) )
-                    {
-                        foreach( $errorINI->variable( 'HTTPError-' . $httpErrorCode, 'HeaderList' ) as $name => $value )
-                        {
-                            // store header on $Result to get it into the content cache
-                            $Result['responseHeaders'][] = $name . ': '. $value;
+					foreach( $headers as $name => $value )
+					{
+						// store header on $Result to get it into the content cache
+						$Result['responseHeaders'][] = $name . ': '. $value;
 
-                            // Copy 'Status' header to a protocol header
-                            // TODO: should use http_response_code()
-                            if( $name == 'Status' )
-                            {
-                                $Result['responseHeaders'][] =
-                                    eZSys::serverVariable( 'SERVER_PROTOCOL' ) . " $httpErrorCode $value";
-                            }
-                        }
+						// Copy 'Status' header to a protocol header
+						// TODO: should use http_response_code()
+						if( $name == 'Status' )
+						{
+							$Result['responseHeaders'][] =
+								eZSys::serverVariable( 'SERVER_PROTOCOL' ) . " $httpErrorCode $value";
+						}
+					}
 
-                        // apply header
-                        foreach( $Result['responseHeaders'] as $header )
-                        {
-                            header( $header );
-                        }
-                    }
-                    
+					// apply header
+					foreach( $Result['responseHeaders'] as $header )
+					{
+						header( $header );
+					}
+
                     // This is triggered if the URL alias translator wants to redirect
                     // to another URL
                     // Not sure why it's wrapped in $errorINI->hasVariable( 'HTTPError-'...
@@ -204,3 +203,26 @@ $Result['errorCode'] = $httpErrorCode;
 $Result['errorMessage'] = $httpErrorName;
 $Result['errorType'] = $errorType;
 $Result['errorNumber'] = $errorNumber;
+
+/**
+ * @param eZINI $errorINI
+ * @param string $httpErrorCode
+ * @return array
+ */
+function kernelErrorGetHeaderList( $errorINI, $httpErrorCode )
+{
+	$return = array();
+
+	if( $errorINI->hasVariable( 'HTTPError-' . $httpErrorCode, 'HeaderList' ) )
+	{
+		$return = $errorINI->variable( 'HTTPError-' . $httpErrorCode, 'HeaderList' );
+	}
+
+	// Make code backwards compatible - "HTTPName" is deprecated
+	if( $errorINI->hasVariable( 'HTTPError-' . $httpErrorCode, 'HTTPName' ) )
+	{
+		$return[ 'Status' ] = $errorINI->variable( 'HTTPError-' . $httpErrorCode, 'HTTPName' );
+	}
+
+	return $return;
+}

--- a/kernel/error/view.php
+++ b/kernel/error/view.php
@@ -70,25 +70,25 @@ $GLOBALS["eZRequestError"] = true;
 
                 if( !empty( $headers ) )
                 {
-					foreach( $headers as $name => $value )
-					{
-						// store header on $Result to get it into the content cache
-						$Result['responseHeaders'][] = $name . ': '. $value;
+                    foreach( $headers as $name => $value )
+                    {
+                        // store header on $Result to get it into the content cache
+                        $Result['responseHeaders'][] = $name . ': '. $value;
 
-						// Copy 'Status' header to a protocol header
-						// TODO: should use http_response_code()
-						if( $name == 'Status' )
-						{
-							$Result['responseHeaders'][] =
-								eZSys::serverVariable( 'SERVER_PROTOCOL' ) . " $httpErrorCode $value";
-						}
-					}
+                        // Copy 'Status' header to a protocol header
+                        // TODO: should use http_response_code()
+                        if( $name == 'Status' )
+                        {
+                            $Result['responseHeaders'][] =
+                                eZSys::serverVariable( 'SERVER_PROTOCOL' ) . " $httpErrorCode $value";
+                        }
+                    }
 
-					// apply header
-					foreach( $Result['responseHeaders'] as $header )
-					{
-						header( $header );
-					}
+                    // apply header
+                    foreach( $Result['responseHeaders'] as $header )
+                    {
+                        header( $header );
+                    }
 
                     // This is triggered if the URL alias translator wants to redirect
                     // to another URL
@@ -211,18 +211,18 @@ $Result['errorNumber'] = $errorNumber;
  */
 function kernelErrorGetHeaderList( $errorINI, $httpErrorCode )
 {
-	$return = array();
+    $return = array();
 
-	if( $errorINI->hasVariable( 'HTTPError-' . $httpErrorCode, 'HeaderList' ) )
-	{
-		$return = $errorINI->variable( 'HTTPError-' . $httpErrorCode, 'HeaderList' );
-	}
+    if( $errorINI->hasVariable( 'HTTPError-' . $httpErrorCode, 'HeaderList' ) )
+    {
+        $return = $errorINI->variable( 'HTTPError-' . $httpErrorCode, 'HeaderList' );
+    }
 
-	// Make code backwards compatible - "HTTPName" is deprecated
-	if( $errorINI->hasVariable( 'HTTPError-' . $httpErrorCode, 'HTTPName' ) )
-	{
-		$return[ 'Status' ] = $errorINI->variable( 'HTTPError-' . $httpErrorCode, 'HTTPName' );
-	}
+    // Make code backwards compatible - "HTTPName" is deprecated
+    if( $errorINI->hasVariable( 'HTTPError-' . $httpErrorCode, 'HTTPName' ) )
+    {
+        $return[ 'Status' ] = $errorINI->variable( 'HTTPError-' . $httpErrorCode, 'HTTPName' );
+    }
 
-	return $return;
+    return $return;
 }

--- a/settings/error.ini
+++ b/settings/error.ini
@@ -102,19 +102,26 @@ HTTPError[1]=404
 # Definition for the HTTP error code 404.
 # It's possible to specify more error codes by creating a group called
 # HTTPError followed by a - (dash) and the HTTP error code.
-# The group most contain the HTTPName variable, if not the error code
-# is not issued to the browser.
-# Note: The HTTPName must be contain the correct string for the
+# The HeaderList variable is a map of response header name to header value.
+# The 'Status' header is special because it's also setting the response
+# content.
+#
+# Note: The Status header must be contain the correct string for the
 #       specific HTTP error code.
 [HTTPError-404]
-HTTPName=Not Found
+HeaderList[]
+HeaderList[Status]=Not Found
+HeaderList[Cache-Control]=public, must-revalidate, max-age=300
 
 # Definition of the HTTP error code 301
 # URL moved permanently
 [HTTPError-301]
-HTTPName=Moved Permanently
+HeaderList[]
+HeaderList[Status]=Moved Permanently
+HeaderList[Cache-Control]=public, must-revalidate, max-age=300
 
 # Definition of the HTTP error code 401
 # Authorization Required
 [HTTPError-401]
-HTTPName=Authorization Required
+HeaderList[]
+HeaderList[Status]=Authorization Required


### PR DESCRIPTION
In ezp it's not possible to set custom response headers for error pages. ezp only allows you to set response headers by requested URLs (see HTTPHeaderSettings in site.ini).

This pull request allows you to specify custom response header for error pages on ezp. That's an important feature in case your site is behind a reverse proxy (CDN akamai, CloudFront, Varnish) and you control the caching TTLs with response headers.

You can test this pull request by accessing a URL that does not exists. From that request you should get a response with this header: 'Cache-Control:public, must-revalidate, max-age=300'

The only small complexity in this pull request is the fact that we re-use the 'Status' header in order to build the response status code - for example '404 Not Found'.