### PR TITLE
Improved documentation for the TagSettings section, now references the ezoe.ini settings

### DIFF
--- a/settings/ezxml.ini
+++ b/settings/ezxml.ini
@@ -41,6 +41,10 @@ AliasClasses[ezpdf]=eZPDFXMLOutput
 # to have different type of editors(aka it only limits the visible buttons,
 # not what you can copy/past or manually enter in code editor)
 # Setting is selectable in class/edit if TagPreset has values.
+# The concrete button configuration for each TagPreset is in ezoe.ini settings
+# file. It needs to contain a [EditorLayout_<identifier>] section matching
+# the TagPreset identifier defined in this setting file. See [EditorLayout_mini]
+# in extension/ezoe/settings/ezoe.ini for an example.
 TagPresets[]
 #TagPresets[full]=All tags
 #TagPresets[mini]=Just formatting allowed


### PR DESCRIPTION
I spent 30 minutes looking at the kernel code to figure out how to configure the TagSettings. The inline documentation should help next time when somebody tries to figure out where to configure the buttons per preset.