### PR TITLE
Add state change/assign to the audit log

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1373,6 +1373,10 @@ class eZContentOperationCollection
             $state = eZContentObjectState::fetchById( $selectedStateID );
             $object->assignState( $state );
         }
+        eZAudit::writeAudit( 'state-assign', array( 'Content object ID' => $object->attribute( 'id' ),
+                                                    'Content object name' => $object->attribute( 'name' ),
+                                                    'Selected State ID Array' => implode( ', ' , $selectedStateIDList ),
+                                                    'Comment' => 'Updated states of the current object: eZContentOperationCollection::updateObjectState()' ) );
         //call appropriate method from search engine
         eZSearch::updateObjectState($objectID, $selectedStateIDList);
 

--- a/settings/audit.ini
+++ b/settings/audit.ini
@@ -47,6 +47,9 @@ AuditFileNames[role-assign]=role_assign.log
 # Who assigns which section at which node (user / section id / section name)
 AuditFileNames[section-assign]=section_assign.log
 
+# Who updated the object states
+AuditFileNames[state-assign]=state_assign.log
+
 # Who deleted which order in shop (user / order id)
 AuditFileNames[order-delete]=order_delete.log
 


### PR DESCRIPTION
We just ran into an issue on one of our customers where it would have been really good to know who made a state change. Thus it would be good to make this an audit log event.