### PR TITLE
Setting to have different cache based on the request protocol

### DIFF
--- a/kernel/classes/eznodeviewfunctions.php
+++ b/kernel/classes/eznodeviewfunctions.php
@@ -349,6 +349,12 @@ class eZNodeviewfunctions
             $cacheNameExtra = $user->attribute( 'contentobject_id' ) . '-';
         }
 
+        // Add the request protocol to the cache key generation
+        if ( strpos( $viewCacheTweak, 'protocol' ) !== false )
+        {
+            $cacheHashArray[] = eZSys::isSSLNow();
+        }
+
         // Make the cache unique for every case of view parameters
         if ( strpos( $viewCacheTweak, 'ignore_viewparameters' ) === false && $viewParameters )
         {

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1137,6 +1137,7 @@ CachedViewModes=full;sitemap;pdf
 # currently supported settings:
 # disabled: Same as setting cache_ttl=0 in template, just a bit more efficient by knowing about it in advance
 # pr_user: cache page pr user, more efficient then disabling view cache and using cache-blocks
+# protocol: builds different cache based on the request protocol (http vs https)
 # ignore_discountlist do not include users shop discountlist in cache hash
 # ignore_userroles do not include users roles in cache hash
 # ignore_userlimitedlist do not include users limted policy assignement list in cache hash


### PR DESCRIPTION
This pull request adds a setting to have different content cache based on request protocol (https vs http).

This is required if your site runs both http and https. If you build full URLs in your content area - those full URLs get cached as content cache. In that case you want to enable the setting to have 2 different content cache versions based on the request protocol.
