### PR TITLE
Fix EZP-26798: Query parameters get lost when being redirected with mobile redirect

### DIFF
--- a/kernel/private/classes/ezpmobiledeviceregexpfilter.php
+++ b/kernel/private/classes/ezpmobiledeviceregexpfilter.php
@@ -129,11 +129,11 @@ class ezpMobileDeviceRegexpFilter implements ezpMobileDeviceDetectFilterInterfac
 
                 if ( array_shift( $uri ) == $currentSiteAccess['name'] )
                 {
-                    $http->redirect( $redirectUrl . '/' . implode( '/', $uri ) );
+                    $http->redirect( $redirectUrl . '/' . implode( '/', $uri ) . eZSys::queryString() );
                 }
                 else
                 {
-                    $http->redirect( $redirectUrl . eZSys::requestURI() );
+                    $http->redirect( $redirectUrl . eZSys::requestURI() . eZSys::queryString() );
                 }
             }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26798

ez system pull request: https://github.com/ezsystems/ezpublish-legacy/pull/1272

I agree with the pull request: the mobile redirect should not lose the query parameters.