### PR TITLE
On image upload, it validates the file mime type. It is preventing file upload if there was a validation error

### DIFF
--- a/settings/image.ini
+++ b/settings/image.ini
@@ -394,3 +394,42 @@ MIMEList[]=image/gif
 Handler=ezexif
 MIMEList[]=image/jpeg
 MIMEList[]=image/tiff
+
+# Controls which image formats are allowed to get uploaded as a
+# content image. Full list of browser supported image mime types:
+# https://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support
+[ValidUploadFormats]
+#jpeg
+MIMEList[]=image/jpeg
+
+#gif
+MIMEList[]=image/gif
+
+#Portable Network Graphics
+MIMEList[]=image/png
+
+#TIFF
+MIMEList[]=image/tiff
+MIMEList[]=image/tiff-fx
+
+#BMP file format
+MIMEList[]=image/bmp
+MIMEList[]=image/x-bmp
+
+# following MIME types are only supported by specific browsers
+
+#X BitMap
+#MIMEList[]=image/x‑xbitmap
+#MIMEList[]=image/x‑xbm
+
+#JPEG 2000
+#MIMEList[]=image/jp2
+#MIMEList[]=image/jpx
+#MIMEList[]=image/jpm
+
+#WebP
+#MIMEList[]=image/webp
+
+# JPEG XR
+#MIMEList[]=image/vnd.ms-photo
+#MIMEList[]=image/jxr


### PR DESCRIPTION
1) Originally, ezp only checked for the file extension when uploading an image file. In case you have the PHP GD extension installed, it checks if the uploaded file is really an image (by loading the image into `getimagesize`).

2) Also, independent of the input validation, ezp used to upload the file to the server. So it was possible to upload an invalid image file. The system would show an error message but then you can just hit 'Send for publishing' a 2nd time and it would accept it.

This patch addresses both points:
1) The input validation will always check if the uploaded file is really an image. It is checking the file mime type against a list of supported mime types configured in the ini settings.

2) In case the input validation failed, ezp will not upload the file. So a user won't be able to upload anything else than a valid image file.
