### PR TITLE
Validate uploaded thumbnail image when creating ez packages

### DIFF
--- a/kernel/classes/ezpackagecreationhandler.php
+++ b/kernel/classes/ezpackagecreationhandler.php
@@ -924,6 +924,11 @@ class eZPackageCreationHandler
         if ( !eZHTTPFile::canFetch( 'PackageThumbnail' ) )
             return true;
 
+        if ( !self::httpFileIsImage( 'PackageThumbnail', $errorList ) )
+        {
+            return false;
+        }
+
         $file = eZHTTPFile::fetch( 'PackageThumbnail' );
 
         $result = true;
@@ -936,6 +941,46 @@ class eZPackageCreationHandler
             $persistentData['thumbnail'] = $mimeData;
         }
         return $result;
+    }
+
+    /**
+     * Check if the HTTP file is an image.
+     *
+     * @param string $httpFileName
+     * @param array $errorList
+     * @return bool
+     */
+    static protected function httpFileIsImage( $httpFileName, &$errorList )
+    {
+        if ( !isset( $_FILES[$httpFileName] ) || $_FILES[$httpFileName]["tmp_name"] === "" )
+        {
+            $errorList[] = array( 'field' => $httpFileName,
+                                  'description' => ezpI18n::tr( 'kernel/package', 'The file does not exist.' ) );
+            return false;
+        }
+
+        if ( !$_FILES[$httpFileName]["size"] )
+        {
+            $errorList[] = array( 'field' => $httpFileName,
+                                  'description' => ezpI18n::tr( 'kernel/package', 'The image file must have non-zero size.' ) );
+            return false;
+        }
+
+        $imageFile = $_FILES[ $httpFileName ][ 'tmp_name' ];
+        $ini = eZINI::instance( 'image.ini' );
+        $fInfo = finfo_open( FILEINFO_MIME_TYPE );
+        $imageType = finfo_file( $fInfo, $imageFile );
+
+        if( !in_array( $imageType, $ini->variable( 'ValidUploadFormats', 'MIMEList' ) ) )
+        {
+            $errorList[] = array(
+                'field' => $httpFileName,
+                'description' => ezpI18n::tr( 'kernel/package', 'A valid image file is required.' )
+            );
+            return false;
+        }
+
+        return true;
     }
 
     /*!

--- a/kernel/classes/packagecreators/ezstyle/ezstylepackagecreator.php
+++ b/kernel/classes/packagecreators/ezstyle/ezstylepackagecreator.php
@@ -231,6 +231,11 @@ class eZStylePackageCreator extends eZPackageCreationHandler
         if ( !eZHTTPFile::canFetch( 'PackageImageFile' ) )
             return true;
 
+        if ( !self::httpFileIsImage( 'PackageImageFile', $errorList ) )
+        {
+            return false;
+        }
+
         $file = eZHTTPFile::fetch( 'PackageImageFile' );
 
         $result = true;


### PR DESCRIPTION
This patch is coming from a ez systems patch on the enterprise version. It prevents users to upload a package thumbnail that is not a valid image file.

You can test this functionality like this:

1. Go to 'setup' -> 'packages'
2. Click 'Create a new package'
3. Select 'Site style' option
4. Click 'Create package'
5. The next view allows you to upload the thumbnail image. Here you can test to upload an invalid image file.

This pull requests depends on https://github.com/mugoweb/ezpublish-legacy/pull/48. Pull request #48 is adding the required settings.