### PR TITLE
Remove the ShowXHTMLCode feature

### DIFF
--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -1741,7 +1741,6 @@ class eZTemplate
      Creates some text nodes before and after the children of \a $root.
      It will extract the current filename and uri and create some XHTML
      comments and inline text.
-     \sa isXHTMLCodeIncluded
     */
     function appendDebugNodes( &$root, &$resourceData )
     {
@@ -1752,8 +1751,6 @@ class eZTemplate
             return;
         $uri = $resourceData['uri'];
         $preText = "\n<!-- START: including template: $path ($uri) -->\n";
-        if ( eZTemplate::isXHTMLCodeIncluded() )
-            $preText .= "<p class=\"small\">$path</p><br/>\n";
         $postText = "\n<!-- STOP: including template: $path ($uri) -->\n";
 
         $preNode = eZTemplateNodeTool::createTextNode( $preText );
@@ -2434,22 +2431,6 @@ class eZTemplate
     public function ini()
     {
         return eZINI::instance( "template.ini" );
-    }
-
-    /*!
-     \static
-     \return true if special XHTML code should be included before the included template file.
-             This code will display the template filename in the browser but will eventually
-             break the design.
-    */
-    static function isXHTMLCodeIncluded()
-    {
-        if ( !isset( $GLOBALS['eZTemplateDebugXHTMLCodeEnabled'] ) )
-        {
-            $ini = eZINI::instance();
-            $GLOBALS['eZTemplateDebugXHTMLCodeEnabled'] = $ini->variable( 'TemplateSettings', 'ShowXHTMLCode' ) == 'enabled';
-        }
-        return $GLOBALS['eZTemplateDebugXHTMLCodeEnabled'];
     }
 
     /*!

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -306,7 +306,6 @@ QuickSettingsList[]
 QuickSettingsList[]=DebugSettings;DebugOutput;site.ini;Debug output
 QuickSettingsList[]=DebugSettings;DebugRedirection;site.ini;Debug redirection
 QuickSettingsList[]=TemplateSettings;Debug;site.ini;Template debug
-QuickSettingsList[]=TemplateSettings;ShowXHTMLCode;site.ini;Inline template debug
 QuickSettingsList[]=TemplateSettings;ShowUsedTemplates;site.ini;List of used templates
 QuickSettingsList[]=DatabaseSettings;SQLOutput;site.ini;SQL debug output
 
@@ -1032,9 +1031,6 @@ ExtensionAutoloadPath[]
 # Warning: Will add debug xhtml comments to your source code, including mails!
 # Note: No debug on templates starting with <!DOCTYPE to not trigger quirks mode!
 Debug=disabled
-# If enabled will add code to display the template name in the browser
-# If Debug is disabled then nothing happens
-ShowXHTMLCode=enabled
 # Whether to show debug of functions and operators when
 # processing nodes.
 # This only meant for kernel developers to check which


### PR DESCRIPTION
IMO, a superfluous feature. Maybe that feature was handy before there were DOM inspection tools in browsers.

The injected HTML p tag is completely ruining the page structure (design).