### PR TITLE
Trim the optimized CSS string to avoid an empty line at the top of the css file

### DIFF
--- a/extension/ezjscore/classes/ezjsccssoptimizer.php
+++ b/extension/ezjscore/classes/ezjsccssoptimizer.php
@@ -72,7 +72,7 @@ class ezjscCssOptimizer
             // Optimize hex colors from #bbbbbb to #bbb
             $css = preg_replace( "/color:#([0-9a-fA-F])\\1([0-9a-fA-F])\\2([0-9a-fA-F])\\3/", "color:#\\1\\2\\3", $css );
         }
-        return $css;
+        return trim( $css );
     }
 }
 ?>


### PR DESCRIPTION
This patch is originally coming from CSM.

The ezjscore CSS optimizer is generating a CSS file with an empty line at the top of the file. It's not a critical problem because browser can handle it. But it's not a valid CSS file. The w3c checker is marking it as an error: https://jigsaw.w3.org/css-validator/

