### PR TITLE
Remove recursive logic for object relation attributes metaData function

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -630,7 +630,7 @@ class eZObjectRelationType extends eZDataType
                     $attributes = $object->contentObjectAttributes();
                 }
 
-                return eZContentObjectAttribute::metaDataArray( $attributes );
+                return eZObjectRelationListType::metaDataArray( $attributes );
             }
             else
             {

--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -618,24 +618,17 @@ class eZObjectRelationType extends eZDataType
         $object = $this->objectAttributeContent( $contentObjectAttribute );
         if ( $object )
         {
-            if ( eZContentObject::recursionProtect( $object->attribute( 'id' ) ) )
+            // Does the related object exist in the same language as the current content attribute ?
+            if ( in_array( $contentObjectAttribute->attribute( 'language_code' ), $object->attribute( 'current' )->translationList( false, false ) ) )
             {
-                // Does the related object exist in the same language as the current content attribute ?
-                if ( in_array( $contentObjectAttribute->attribute( 'language_code' ), $object->attribute( 'current' )->translationList( false, false ) ) )
-                {
-                    $attributes = $object->attribute( 'current' )->contentObjectAttributes( $contentObjectAttribute->attribute( 'language_code' ) );
-                }
-                else
-                {
-                    $attributes = $object->contentObjectAttributes();
-                }
-
-                return eZObjectRelationListType::metaDataArray( $attributes );
+                $attributes = $object->attribute( 'current' )->contentObjectAttributes( $contentObjectAttribute->attribute( 'language_code' ) );
             }
             else
             {
-                return array();
+                $attributes = $object->contentObjectAttributes();
             }
+
+            return eZObjectRelationListType::metaDataArray( $attributes );
         }
         return false;
     }

--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -628,7 +628,7 @@ class eZObjectRelationType extends eZDataType
                 $attributes = $object->contentObjectAttributes();
             }
 
-            return eZObjectRelationListType::metaDataArray( $attributes );
+            return self::metaDataArray( $attributes );
         }
         return false;
     }
@@ -807,6 +807,46 @@ class eZObjectRelationType extends eZDataType
     }
 
     /// \privatesection
+
+    /**
+     * Goes trough all attributes and fetches metadata for the ones that is searchable.
+     * Returns an array with metadata information.
+     *
+     * @param $attributes
+     * @return array|bool
+     */
+    private static function metaDataArray( &$attributes )
+    {
+        $metaDataArray = array();
+        if ( !is_array( $attributes ) )
+            return false;
+        foreach( $attributes as $attribute )
+        {
+            $classAttribute = $attribute->contentClassAttribute();
+            $excludeDataTypes = array( 'ezobjectrelationlist', 'ezobjectrelation' );
+
+            if (
+                $classAttribute->attribute( 'is_searchable' ) &&
+                ! in_array( $classAttribute->attribute( 'data_type_string' ), $excludeDataTypes )
+            )
+            {
+                $attributeMetaData = $attribute->metaData();
+                if ( $attributeMetaData !== false )
+                {
+                    if ( !is_array( $attributeMetaData ) )
+                    {
+                        $attributeMetaData = array( array(
+                            'id' => '',
+                            'text' => $attributeMetaData
+                        ) );
+                    }
+                    $metaDataArray = array_merge( $metaDataArray, $attributeMetaData );
+                }
+            }
+        }
+        return $metaDataArray;
+    }
+
 }
 
 eZDataType::register( eZObjectRelationType::DATA_TYPE_STRING, "eZObjectRelationType" );

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -1612,24 +1612,24 @@ class eZObjectRelationListType extends eZDataType
                 $subObjectVersionNum = $relationItem['contentobject_version'];
                 $subObject = eZContentObject::fetch( $subObjectID );
 
-                // Using last version of object (version inside xml data is the original version)
-                $subCurrentVersionObject = $subObject->currentVersion();
-                if( $subCurrentVersionObject instanceof eZContentObjectVersion )
+                if ( $subObject )
                 {
-                    $subObjectVersionNum = $subCurrentVersionObject->attribute( 'version' );
-                }
-
-                if ( eZContentObject::recursionProtect( $subObjectID ) )
-                {
-                    if ( !$subObject )
+                    // Using last version of object (version inside xml data is the original version)
+                    $subCurrentVersionObject = $subObject->currentVersion();
+                    if( $subCurrentVersionObject instanceof eZContentObjectVersion )
                     {
-                        continue;
+                        $subObjectVersionNum = $subCurrentVersionObject->attribute( 'version' );
                     }
+
                     $attributes = $subObject->contentObjectAttributes( true, $subObjectVersionNum, $language );
+                }
+                else
+                {
+                    continue;
                 }
             }
 
-            $attributeMetaDataArray = eZContentObjectAttribute::metaDataArray( $attributes );
+            $attributeMetaDataArray = self::metaDataArray( $attributes );
             $metaDataArray = array_merge( $metaDataArray, $attributeMetaDataArray );
         }
 
@@ -1934,6 +1934,43 @@ class eZObjectRelationListType extends eZDataType
     function supportsBatchInitializeObjectAttribute()
     {
         return true;
+    }
+
+    /**
+     * Goes trough all attributes and fetches metadata for the ones that is searchable.
+     * Returns an array with metadata information.
+     *
+     * @param $attributes
+     * @return array|bool
+     */
+    public static function metaDataArray( &$attributes )
+    {
+        $metaDataArray = array();
+        if ( !is_array( $attributes ) )
+            return false;
+        foreach( $attributes as $attribute )
+        {
+            $classAttribute = $attribute->contentClassAttribute();
+            $excludeDataTypes = array( 'ezobjectrelationlist', 'ezobjectrelation' );
+
+            if (
+                $classAttribute->attribute( 'is_searchable' ) &&
+                ! in_array( $classAttribute->attribute( 'data_type_string' ), $excludeDataTypes )
+            )
+            {
+                $attributeMetaData = $attribute->metaData();
+                if ( $attributeMetaData !== false )
+                {
+                    if ( !is_array( $attributeMetaData ) )
+                    {
+                        $attributeMetaData = array( array( 'id' => '',
+                            'text' => $attributeMetaData ) );
+                    }
+                    $metaDataArray = array_merge( $metaDataArray, $attributeMetaData );
+                }
+            }
+        }
+        return $metaDataArray;
     }
 
     /// \privatesection

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -1935,6 +1935,8 @@ class eZObjectRelationListType extends eZDataType
     {
         return true;
     }
+    
+    /// \privatesection
 
     /**
      * Goes trough all attributes and fetches metadata for the ones that is searchable.
@@ -1943,7 +1945,7 @@ class eZObjectRelationListType extends eZDataType
      * @param $attributes
      * @return array|bool
      */
-    public static function metaDataArray( &$attributes )
+    private static function metaDataArray( &$attributes )
     {
         $metaDataArray = array();
         if ( !is_array( $attributes ) )
@@ -1963,8 +1965,10 @@ class eZObjectRelationListType extends eZDataType
                 {
                     if ( !is_array( $attributeMetaData ) )
                     {
-                        $attributeMetaData = array( array( 'id' => '',
-                            'text' => $attributeMetaData ) );
+                        $attributeMetaData = array( array(
+                            'id' => '',
+                            'text' => $attributeMetaData
+                        ) );
                     }
                     $metaDataArray = array_merge( $metaDataArray, $attributeMetaData );
                 }
@@ -1973,7 +1977,6 @@ class eZObjectRelationListType extends eZDataType
         return $metaDataArray;
     }
 
-    /// \privatesection
 }
 
 eZDataType::register( eZObjectRelationListType::DATA_TYPE_STRING, "eZObjectRelationListType" );

--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -1162,38 +1162,6 @@ class eZContentObjectAttribute extends eZPersistentObject
             return false;
     }
 
-
-    /*!
-     \static
-     Goes trough all attributes and fetches metadata for the ones that is searchable.
-     \return an array with metadata information.
-    */
-    static function metaDataArray( &$attributes )
-    {
-        $metaDataArray = array();
-        if ( !is_array( $attributes ) )
-            return false;
-        foreach( $attributes as $attribute )
-        {
-            $classAttribute = $attribute->contentClassAttribute();
-            if ( $classAttribute->attribute( 'is_searchable' ) )
-            {
-                $attributeMetaData = $attribute->metaData();
-                if ( $attributeMetaData !== false )
-                {
-                    if ( !is_array( $attributeMetaData ) )
-                    {
-                        $attributeMetaData = array( array( 'id' => '',
-                                                           'text' => $attributeMetaData ) );
-                    }
-                    $metaDataArray = array_merge( $metaDataArray, $attributeMetaData );
-                }
-            }
-        }
-        return $metaDataArray;
-    }
-
-
     /*!
      Sets the content for the current attribute
     */


### PR DESCRIPTION
Each datatype has the function metaData(). It's used by the search engine in order to get attribute content you want to put in to the search index. For ezstring is it just the string that is stored in the attribute.

It's more complex for an object relation attribute (ezobjectrelation and ezobjectrelationlist). In that case, the metaData function is looking up the related object and collects all searchable data on the related content object. 

So if you have an article with an object relation attribute to configure related articles, the metaData for that attribute will collect all data from the related article.
Now let's assume the related article also has an object relation attribute to an image object. Again, the metaData function will lookup the related object and collect all data from the image data map.
That recursive logic will follow all object relations and puts all collected data into the search index for one single attribute.

This pull request is removing the recursive logic. For an article object relation attribute, it will only collect all data of the related article. Object relations on the related article are ignored (like the image object in the previous example).

With this pull request, we will only index closely related data. It also avoids a problem the upstream version currently has: https://github.com/ezsystems/ezpublish-legacy/pull/1288

Technical details:
I moved the function 'metaDataArray' from ezcontentobjectattribute to ezobjectrelationlisttype. That function is very specific to the ezobjectrelationlisttype and ezobjectrelationtype datatype. Only those 2 classes are calling the function. That's why I believe it does not belong to ezcontentobjectattribute.

I removed the recursion protection from ezobjectrelationlisttype and ezobjectrelationtype datatypes (function metaData). It's not needed when there is no recursion.
