### PR TITLE
Object info has a new section "Published version" containing all details if it exists

### DIFF
--- a/design/admin/templates/content/parts/object_information.tpl
+++ b/design/admin/templates/content/parts/object_information.tpl
@@ -4,12 +4,6 @@
     </div>
 
     <div class="box-content">
-        {* Object ID *}
-        <p>
-            <label>{'ID'|i18n( 'design/admin/content/history' )}:</label>
-            {$object.id}
-        </p>
-
         {* Created *}
         <p>
             <label>{'Created'|i18n( 'design/admin/content/history' )}:</label>
@@ -19,6 +13,11 @@
             {else}
                 {'Not yet published'|i18n( 'design/admin/content/history' )}
             {/if}
+        </p>
+        {* Object ID *}
+        <p>
+            <label>{'ID'|i18n( 'design/admin/content/history' )}:</label>
+            {$object.id}
         </p>
     </div>
 
@@ -30,9 +29,9 @@
     <div class="box-content">
         {if $object.published}
             <p>
-                <label>{'Created'|i18n( 'design/admin/content/history' )}:</label>
-                {$object.current.creator.name|wash}<br />
-                {$object.current.modified|l10n( shortdatetime )}
+                <label>{'Published'|i18n( 'design/admin/content/history' )}:</label>
+                {$object.current.modified|l10n( shortdatetime )}<br />
+                {$object.current.creator.name|wash}
             </p>
             <p>
                 <label>{'Version'|i18n( 'design/admin/content/history' )}:</label>

--- a/design/admin/templates/content/parts/object_information.tpl
+++ b/design/admin/templates/content/parts/object_information.tpl
@@ -1,63 +1,56 @@
 <div class="objectinfo">
+    <div class="box-header">
+        <h4>{'Object information'|i18n( 'design/admin/content/history' )}</h4>
+    </div>
 
-{* DESIGN: Header START *}<div class="box-header">
+    <div class="box-content">
+        {* Object ID *}
+        <p>
+            <label>{'ID'|i18n( 'design/admin/content/history' )}:</label>
+            {$object.id}
+        </p>
 
-<h4>{'Object information'|i18n( 'design/admin/content/history' )}</h4>
+        {* Created *}
+        <p>
+            <label>{'Created'|i18n( 'design/admin/content/history' )}:</label>
+            {if $object.published}
+                {$object.published|l10n( shortdatetime )}<br />
+                {$object.owner.name|wash}
+            {else}
+                {'Not yet published'|i18n( 'design/admin/content/history' )}
+            {/if}
+        </p>
+    </div>
 
-{* DESIGN: Header END *}</div>
+    {* Published version*}
+    <div class="box-header">
+        <h4>{'Published version'|i18n( 'design/admin/content/history' )}</h4>
+    </div>
 
-{* DESIGN: Content START *}<div class="box-content">
+    <div class="box-content">
+        {if $object.published}
+            <p>
+                <label>{'Created'|i18n( 'design/admin/content/history' )}:</label>
+                {$object.current.creator.name|wash}<br />
+                {$object.current.modified|l10n( shortdatetime )}
+            </p>
+            <p>
+                <label>{'Version'|i18n( 'design/admin/content/history' )}:</label>
+                {$object.published_version}
+            </p>
+        {else}
+            <p>{'Not yet published'|i18n( 'design/admin/content/history' )}</p>
+        {/if}
 
-{* Object ID *}
-<p>
-<label>{'ID'|i18n( 'design/admin/content/history' )}:</label>
-{$object.id}
-</p>
-
-{* Created *}
-<p>
-<label>{'Created'|i18n( 'design/admin/content/history' )}:</label>
-{if $object.published}
-{$object.published|l10n( shortdatetime )}<br />
-{$object.owner.name|wash}
-{else}
-{'Not yet published'|i18n( 'design/admin/content/history' )}
-{/if}
-</p>
-
-{* Modified *}
-<p>
-<label>{'Modified'|i18n( 'design/admin/content/history' )}:</label>
-{if $object.modified}
-{def $latest_version=$object.versions|extract_right(1)[0]}
-{$object.modified|l10n( shortdatetime )}<br />
-{$latest_version.creator.name|wash}
-{else}
-{'Not yet published'|i18n( 'design/admin/content/history' )}
-{/if}
-</p>
-
-{* Published version*}
-<p>
-<label>{'Published version'|i18n( 'design/admin/content/history' )}:</label>
-{if $object.published}
-{$object.published_version}
-{else}
-{'Not yet published'|i18n( 'design/admin/content/history' )}
-{/if}
-</p>
-
-{if and( is_set($manage_version_button), $manage_version_button )}
-{* Manage versions *}
-<div class="block">
-{if $object.versions|count|gt( 1 )}
-<input class="button" type="submit" name="VersionsButton" value="{'Manage versions'|i18n( 'design/admin/content/view/versionview' )}" title="{'View and manage (copy, delete, etc.) the versions of this object.'|i18n( 'design/admin/content/view/versionview' )}" />
-{else}
-<input class="button-disabled" type="submit" name="VersionsButton" value="{'Manage versions'|i18n( 'design/admin/content/view/versionview' )}" disabled="disabled" title="{'You cannot manage the versions of this object because there is only one version available (the one that is being displayed).'|i18n( 'design/admin/content/view/versionview' )}" />
-{/if}
-</div>
-{/if}
-
-{* DESIGN: Content END *}</div>
-
+        {if and( is_set($manage_version_button), $manage_version_button )}
+            {* Manage versions *}
+            <div class="block">
+                {if $object.versions|count|gt( 1 )}
+                    <input class="button" type="submit" name="VersionsButton" value="{'Manage versions'|i18n( 'design/admin/content/view/versionview' )}" title="{'View and manage (copy, delete, etc.) the versions of this object.'|i18n( 'design/admin/content/view/versionview' )}" />
+                {else}
+                    <input class="button-disabled" type="submit" name="VersionsButton" value="{'Manage versions'|i18n( 'design/admin/content/view/versionview' )}" disabled="disabled" title="{'You cannot manage the versions of this object because there is only one version available (the one that is being displayed).'|i18n( 'design/admin/content/view/versionview' )}" />
+                {/if}
+            </div>
+        {/if}
+    </div>
 </div>


### PR DESCRIPTION
This pull requests affects the "object_information.tpl" template. It is shown if you edit a content object of if you look at the version history for a content object.

http://devmanage.lovestack.mugo.ca/content/history/58
http://devmanage.lovestack.mugo.ca/content/edit/58

The top section "Object information" contains the details:
**ID** (object ID)
**Created** (creation time + creator user name)
**Modified** (object modification + user name of that last modification)
**Published version** (version id number)

The **Modified** details are buggy currently - see:
https://github.com/ezsystems/ezpublish-legacy/pull/1296

The pull request 1296 fixes the issue - but I think it's worth considering to also re-organize the object information a little. This pull request fixes the buggy **Modified** details and additionally puts the details from **Modified** and **Published version** into a dedicated section called 'Published version'.

See the 2 screenshots:

NEW:
<img width="1150" alt="screen shot 2017-05-09 at 15 12 16" src="https://cloud.githubusercontent.com/assets/971684/25852519/edd8daae-34c9-11e7-92be-be195de6b5f5.png">

OLD:
<img width="1158" alt="screen shot 2017-05-09 at 15 12 08" src="https://cloud.githubusercontent.com/assets/971684/25852535/fa231504-34c9-11e7-82a7-528f770aa699.png">
