### PR TITLE
Move the PHP function ezcontentobjecttreenodeoperations::move to ezcontentoperationcollection::move

### DIFF
--- a/kernel/classes/ezcontentobjecttreenodeoperations.php
+++ b/kernel/classes/ezcontentobjecttreenodeoperations.php
@@ -8,47 +8,22 @@
  * @package kernel
  */
 
-/*!
-  \class eZContentObjectTreeNodeOperations ezcontentobjecttreenodeoperations.php
-  \brief The class eZContentObjectTreeNodeOperations is a wrapper for node's
-  core-operations. It takes care about interface stuff.
-  Example: there is a 'move' core-operation that moves a node from one location
-  to another. But, for example, before and after moving we have to clear
-  view caches for old and new placements. Clearing of the cache is handled by
-  this class.
-*/
-
+/**
+ * Class eZContentObjectTreeNodeOperations
+ *
+ * @deprecated Use eZContentOperationCollection instead
+ */
 class eZContentObjectTreeNodeOperations
 {
-    /*!
-     Constructor
-    */
-    function eZContentObjectTreeNodeOperations()
-    {
-    }
-
-    /*!
-     \static
-     A wrapper for eZContentObjectTreeNode's 'move' operation.
-     It does:
-      - clears caches for old placement;
-      - performs actual move( calls eZContentObjectTreeNode->move() );
-      - updates subtree path;
-      - updates node's section;
-      - updates assignment( setting new 'parent_node' );
-      - clears caches for new placement;
-
-     \param $nodeID The id of a node to move.
-     \param $newParentNodeID The id of a new parent.
-     \return \c true if 'move' was done successfully, otherwise \c false;
-    */
+    /**
+     * @deprected use eZContentOperationCollection::moveNode instead
+     * @param $nodeID
+     * @param $newParentNodeID
+     * 
+     * @return boolean
+     */
     static function move( $nodeID, $newParentNodeID )
     {
-        $result = false;
-
-        if ( !is_numeric( $nodeID ) || !is_numeric( $newParentNodeID ) )
-            return false;
-
         $node = eZContentObjectTreeNode::fetch( $nodeID );
         if ( !$node )
             return false;
@@ -58,84 +33,10 @@ class eZContentObjectTreeNodeOperations
             return false;
 
         $objectID = $object->attribute( 'id' );
-        $oldParentNode = $node->fetchParent();
-        $oldParentObject = $oldParentNode->object();
 
-        // clear user policy cache if this is a user object
-        if ( in_array( $object->attribute( 'contentclass_id' ), eZUser::contentClassIDs() ) )
-        {
-            eZUser::purgeUserCacheByUserId( $object->attribute( 'id' ) );
-        }
+        $result = eZContentOperationCollection::moveNode( $nodeID, $objectID, $newParentNodeID );
 
-        // clear cache for old placement.
-        // If child count exceeds threshold, do nothing here, and instead clear all view cache at the end.
-        $childCountInThresholdRange = eZContentCache::inCleanupThresholdRange( $node->childrenCount( false ) );
-        if ( $childCountInThresholdRange )
-        {
-            eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
-        }
-
-        $db = eZDB::instance();
-        $db->begin();
-
-        $node->move( $newParentNodeID );
-
-        $newNode = eZContentObjectTreeNode::fetchNode( $objectID, $newParentNodeID );
-
-        if ( $newNode )
-        {
-            $newNode->updateSubTreePath( true, true );
-            if ( $newNode->attribute( 'main_node_id' ) == $newNode->attribute( 'node_id' ) )
-            {
-                // If the main node is moved we need to check if the section ID must change
-                $newParentNode = $newNode->fetchParent();
-                $newParentObject = $newParentNode->object();
-                if ( $object->attribute( 'section_id' ) != $newParentObject->attribute( 'section_id' ) )
-                {
-
-                    eZContentObjectTreeNode::assignSectionToSubTree( $newNode->attribute( 'main_node_id' ),
-                                                                     $newParentObject->attribute( 'section_id' ),
-                                                                     $oldParentObject->attribute( 'section_id' ) );
-                }
-            }
-
-            // modify assignment
-            $curVersion     = $object->attribute( 'current_version' );
-            $nodeAssignment = eZNodeAssignment::fetch( $objectID, $curVersion, $oldParentNode->attribute( 'node_id' ) );
-
-            if ( $nodeAssignment )
-            {
-                $nodeAssignment->setAttribute( 'parent_node', $newParentNodeID );
-                $nodeAssignment->setAttribute( 'op_code', eZNodeAssignment::OP_CODE_MOVE );
-                $nodeAssignment->store();
-
-                // update search index specifying we are doing a move operation
-                $nodeIDList = array( $nodeID );
-                eZSearch::removeNodeAssignment( $node->attribute( 'main_node_id' ), $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList );
-                eZSearch::addNodeAssignment( $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList, true );
-            }
-
-            $result = true;
-        }
-        else
-        {
-            eZDebug::writeError( "Node $nodeID was moved to $newParentNodeID but fetching the new node failed" );
-        }
-
-        $db->commit();
-
-        // clear cache for new placement.
-        // If child count exceeds threshold, clear all view cache instead.
-        if ( $childCountInThresholdRange )
-        {
-            eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
-        }
-        else
-        {
-            eZContentCacheManager::clearAllContentCache();
-        }
-
-        return $result;
+        return $result[ 'status' ];
     }
 }
 


### PR DESCRIPTION
This pull request is not fixing a bug. It's moving code to make the ezp API a little more consistent.

There a 3 PHP functions to move a node:

1. eZContentObjectTreeNode::move - https://github.com/mugoweb/ezpublish-legacy/blob/master/kernel/classes/ezcontentobjecttreenode.php#L4238
2. eZContentOperationCollection::moveNode - https://github.com/mugoweb/ezpublish-legacy/blob/master/kernel/content/ezcontentoperationcollection.php#L727
3. eZContentObjectTreeNodeOperations::move - https://github.com/mugoweb/ezpublish-legacy/blob/master/kernel/classes/ezcontentobjecttreenodeoperations.php#L45

For 1)
eZContentObjectTreeNode extends eZPersistentObject. Its main purpose is to update the DB related entries if you move a node.
For 2)
This function is a wrapper to eZContentObjectTreeNode::move: it internally calls eZContentObjectTreeNode::move but does extra stuff like clearing cache, updating the search index, logging to the audit log etc etc. Basically a higher level of the ezp API.
For 3)
I think that function should not exists. It is pretty much the same as 2) but in another class.  This class only contains a single function 'move'. It was developed in context of the WebDAV integration:
https://github.com/bernhard-roessler/ezpublish-legacy/blame/f1d42b6facfbef92fbc7114a4fc5e45a7d4f6565/kernel/classes/ezcontentobjecttreenodeoperations.php

For an API consumer, it would be simpler if there is only 1) and 2) and not that extra wrapper function described in 3).

I resolve this problem by marking 3) as deprecated. Internally, the function is calling eZContentOperationCollection::moveNode.

*My code changes*

You will see that eZContentOperationCollection::moveNode used to call eZContentObjectTreeNodeOperations::move. The heavy lifting happened in eZContentObjectTreeNodeOperations::move. eZContentOperationCollection::moveNode was only a wrapper function doing 2 extra things:
1) fixing reverse relations
2) re-indexing the node

Now it is the opposite: eZContentObjectTreeNodeOperations::move is now only a deprecated wrapper. All actual code to move a node is in eZContentOperationCollection::moveNode.

