### PR TITLE
Replace the zeta component archive usage in ezpackage::import - it no…

### DIFF
--- a/kernel/classes/ezpackage.php
+++ b/kernel/classes/ezpackage.php
@@ -1136,12 +1136,13 @@ class eZPackage
                     copy( $archiveName, $tmpFile );
                 }
 
-                $phar = new PharData( $tmpFile, FilesystemIterator::SKIP_DOTS, 'pharPackage', Phar::GZ );
+                $phar = new PharData( $tmpFile );
                 $phar->extractTo( $archivePath, $fileList, true );
             }
             catch( Exception $e )
             {
                 eZDebug::writeError( "Failed loading temporary package $packageName" );
+				return false;
             }
 
             $definitionFileName = eZDir::path( array( $archivePath, self::definitionFilename() ) );

--- a/kernel/classes/ezpackage.php
+++ b/kernel/classes/ezpackage.php
@@ -1142,7 +1142,7 @@ class eZPackage
             catch( Exception $e )
             {
                 eZDebug::writeError( "Failed loading temporary package $packageName" );
-				return false;
+                return false;
             }
 
             $definitionFileName = eZDir::path( array( $archivePath, self::definitionFilename() ) );


### PR DESCRIPTION
…w uses standard PHP phar functionality

The installation wizzard and the ez package functionality is not working correctly unless you use a recent version of the zeta components.

This pull requests removes the usage of the unsupported zeta components in ezpackage:import and uses standard PHP functionality instead.
