### PR TITLE
Fix ezp 27254 unknow relation type 0

### DIFF
--- a/kernel/classes/datatypes/ezxmltext/ezxmltexttype.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmltexttype.php
@@ -162,11 +162,19 @@ class eZXMLTextType extends eZDataType
         // eZContentObject->fetchAttributesByIdentifier() to get the data
         $identifier = $contentObjectAttribute->attribute( 'contentclass_attribute_identifier' );
 
-        $attributeArray = $object->fetchAttributesByIdentifier( array( $identifier ),
-                                                                $currentVersion->attribute( 'version' ),
-                                                                $languageList );
+		$attributeArray = eZPersistentObject::fetchObjectList(
+		    eZContentObjectAttribute::definition(),
+			null,
+			array(
+			    'data_type_string' => 'ezxmltext',
+				'contentobject_id' => $object->ID,
+				'version' => $currentVersion->attribute( 'version' ),
+            ),
+			null,
+			null,
+			true );
 
-        foreach ( $attributeArray as $attribute )
+		foreach ( $attributeArray as $attribute )
         {
             $xmlText = eZXMLTextType::rawXMLText( $attribute );
 
@@ -209,13 +217,13 @@ class eZXMLTextType extends eZDataType
             {
                 $object->appendInputRelationList( $linkedObjectIdArray, eZContentObject::RELATION_LINK );
             }
-            if ( !empty( $linkedObjectIdArray ) || !empty( $embeddedObjectIdArray ) )
-            {
-                $object->commitInputRelations( $currentVersion->attribute( 'version' ) );
-            }
-
         }
-    }
+
+		if ( !empty( $linkedObjectIdArray ) || !empty( $embeddedObjectIdArray ) )
+		{
+			$object->commitInputRelations( $currentVersion->attribute( 'version' ) );
+		}
+	}
 
     /**
      * Extracts ids of embedded/linked objects in an eZXML DOMNodeList

--- a/kernel/classes/datatypes/ezxmltext/ezxmltexttype.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmltexttype.php
@@ -149,32 +149,22 @@ class eZXMLTextType extends eZDataType
     function onPublish( $contentObjectAttribute, $object, $publishedNodes )
     {
         $currentVersion = $object->currentVersion();
-        $langMask = $currentVersion->attribute( 'language_mask' );
 
-        // We find all translations present in the current version. We calculate
-        // this from the language mask already present in the fetched version,
-        // so no further round-trip to the DB is required.
-        $languageList = eZContentLanguage::decodeLanguageMask( $langMask, true );
-        $languageList = $languageList['language_list'];
-
-        // We want to have the class attribute identifier of the attribute
-        // containing the current ezxmltext, as we then can use the more efficient
-        // eZContentObject->fetchAttributesByIdentifier() to get the data
-        $identifier = $contentObjectAttribute->attribute( 'contentclass_attribute_identifier' );
-
-		$attributeArray = eZPersistentObject::fetchObjectList(
-		    eZContentObjectAttribute::definition(),
-			null,
-			array(
-			    'data_type_string' => 'ezxmltext',
-				'contentobject_id' => $object->ID,
-				'version' => $currentVersion->attribute( 'version' ),
+        //Fetches all ezxmltext attributes for the given object
+        $attributeArray = eZPersistentObject::fetchObjectList(
+            eZContentObjectAttribute::definition(),
+            null,
+            array(
+                'data_type_string' => 'ezxmltext',
+                'contentobject_id' => $object->ID,
+                'version' => $currentVersion->attribute( 'version' ),
             ),
-			null,
-			null,
-			true );
+            null,
+            null,
+            true );
 
-		foreach ( $attributeArray as $attribute )
+        // builds a list of object relations
+        foreach ( $attributeArray as $attribute )
         {
             $xmlText = eZXMLTextType::rawXMLText( $attribute );
 
@@ -219,11 +209,12 @@ class eZXMLTextType extends eZDataType
             }
         }
 
-		if ( !empty( $linkedObjectIdArray ) || !empty( $embeddedObjectIdArray ) )
-		{
-			$object->commitInputRelations( $currentVersion->attribute( 'version' ) );
-		}
-	}
+        // write object relations for this version
+        if ( !empty( $linkedObjectIdArray ) || !empty( $embeddedObjectIdArray ) )
+        {
+            $object->commitInputRelations( $currentVersion->attribute( 'version' ) );
+        }
+    }
 
     /**
      * Extracts ids of embedded/linked objects in an eZXML DOMNodeList


### PR DESCRIPTION
The issue:
https://jira.ez.no/browse/EZP-27254

I pull request that got merged to fix the issue:
https://github.com/ezsystems/ezpublish-legacy/pull/1295

This pull request is different to the upstream pull request. This pull request fixes the root cause and is not fixing the symptom. See my comment on June 27 https://github.com/ezsystems/ezpublish-legacy/pull/1295

How to test this pull request:
1) Create a new article (or another content class with 2 ezxmltext attributes)
2) Embed objects in 2 ezxmltext attributes (for example "Summary" and "Body")
3) Send for publishing
4) Check the DB content with: "select * from ezcontentobject_link where from_contentobject_id = <objID of newly created content object>;"
5) Confirm you see 2 entries for version 1
6) Re-publish the article
7) Confirm you see 2 entries for version 2

Try other scenarios with multiple languages, and also removal of embedded objects in the ezxmltext attributes.
