### PR TITLE
Clearing content cache after re-indexing an ezp object

### DIFF
--- a/cronjobs/indexcontent.php
+++ b/cronjobs/indexcontent.php
@@ -114,6 +114,7 @@ while( true )
             if ( $removeFromPendingActions )
             {
                 $db->query( "DELETE FROM ezpending_actions WHERE action = '$action' AND param = '$objectID'" );
+                eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
             }
             else
             {


### PR DESCRIPTION
Pull request at upstream:

https://github.com/ezsystems/ezpublish-legacy/pull/1210
