### PR TITLE
Clear content cache on node priority update

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1260,6 +1260,7 @@ class eZContentOperationCollection
              $db->commit();
              if ( !eZSearch::getEngine() instanceof eZSearchEngine )
              {
+                 eZContentCacheManager::clearContentCacheIfNeeded( $objectIDs );
                  foreach ( $objectIDs as $objectID )
                  {
                      eZContentOperationCollection::registerSearchObject( $objectID );


### PR DESCRIPTION
It's from a patch that got merged on upstream:

https://github.com/ezsystems/ezpublish-legacy/pull/1312
