### PR TITLE
Avoid DB error due to invalid integer value while adding object to the search index

### DIFF
--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -297,7 +297,8 @@ class eZSearchEngine implements ezpSearchEngine
             $indexWord = $indexArray[$i]['Word'];
             $contentClassAttributeID = $indexArray[$i]['ContentClassAttributeID'];
             $identifier = $indexArray[$i]['identifier'];
-            $integerValue = $indexArray[$i]['integer_value'];
+            $integerValue = min( $indexArray[$i]['integer_value'], $db->MAX_INT );
+            $integerValue = max( $integerValue, $db->MIN_INT );
             $wordID = $wordIDArray[$indexWord];
 
             if ( isset( $indexArray[$i+1] ) )

--- a/lib/ezdb/classes/ezdbinterface.php
+++ b/lib/ezdb/classes/ezdbinterface.php
@@ -1809,6 +1809,20 @@ class eZDBInterface
      * @var int One of the eZDB::ERROR_HANDLING_* constants
      */
     protected $errorHandling = eZDB::ERROR_HANDLING_STANDARD;
+
+    /**
+     * Maximal value for mysql int columns
+     *
+     * @var int
+     */
+    public $MAX_INT = 2147483647;
+
+    /**
+     * Minimal value for mysql int columns
+     *
+     * @var int
+     */
+    public $MIN_INT = -2147483648;
 }
 
 ?>


### PR DESCRIPTION
You run into a DB error if you use the default search engine (not solr) and an attribute happens to contain a number that is bigger than the maximal integer size allowed by the DB.

How to reproduce the issue:

1) Use a content class that has a ezstring (text) attribute
2) Create a new node
3) In the text field type in following content: 3147483647
4) Send the new node for publishing

It will result in a fatal error, showing a DB transaction error.

That's due to the fact that `kernel/search/plugins/ezsearchengine/ezsearchengine.php` tries to save an integer value in the DB table `ezsearch_object_word_link` column `integer_value`. That PHP file is checking if the given attribute value is a numeric value:

https://github.com/mugoweb/ezpublish-legacy/blob/master/kernel/search/plugins/ezsearchengine/ezsearchengine.php#L97

If that's the case, it will try to store the integer value but it does not check if the value can be saved to the DB due to the limitation (max/min value) of a integer column in the DB.

This patch is limiting the integer value to the maximal/minimal value the DB can handle. Therefore it will not run into a SQL error (transaction error message).

That issue is known - here is the issue report:
https://jira.ez.no/browse/EZP-26209?jql=text%20~%20%22Out%20of%20range%20value%20for%20column%20%27integer_value%27%22

There is even a pull request:
https://github.com/ezsystems/ezpublish-legacy/pull/1268

I decided not to use the pull request because it's not checking for the min value. Also, the information about the max/min integer value should be set in the DB API classes and not in
https://github.com/mugoweb/ezpublish-legacy/blob/master/kernel/search/plugins/ezsearchengine/ezsearchengine.php

References:
https://dev.mysql.com/doc/refman/5.7/en/integer-types.html
https://www.postgresql.org/docs/9.1/static/datatype-numeric.html
