### PR TITLE
Removing PHP 5.3 from the travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -22,10 +21,6 @@ env:
 # Aim to run tests on all versions of php, make sure each db is run at least once
 matrix:
   exclude:
-    - php: 5.3.3
-      env: DB="postgresql" DB_USER="postgres"
-    - php: 5.3
-      env: DB="mysql" DB_USER="root"
     - php: 5.4
       env: DB="postgresql" DB_USER="postgres"
     - php: 5.5


### PR DESCRIPTION
The automated unit tests with travis fail because the setup does not include PHP 5.3 anymore. I'm pretty sure that most of our clients use a more recent PHP version. And in case we want them to upgrade to a new ezpublish version, we probably would consider to use PHP7 anyways. So I decided to remove the test run using PHP 5.3. Other PHP versions are still in use 5.4, 5.5 and 5.6.

In another pull request we should add PHP 7.