### PR TITLE
Pure PHP script to run schema updates on the DB

### DIFF
--- a/settings/site.ini
+++ b/settings/site.ini
@@ -556,7 +556,7 @@ UserGroupClassID=3
 UserClassGroupID=2
 # Which user is considered the creator
 UserCreatorID=14
-# Use either md5_password, md5_user, md5_site or plaintext
+# Use either md5_password, md5_user, md5_site, bcrypt, php_default or plaintext
 # md5_password generates password hash from password only.
 # md5_user generates password hash from user and password.
 # md5_site generates password hash from site, user and password
@@ -566,6 +566,8 @@ UserCreatorID=14
 # php_default uses whichever method PHP deems appropriate (currently bcrypt, as of PHP 5.5)
 # note: password hashes generated with md5_site will not work after
 #       changing the site name.
+# note: The DB schema changed to support bcrypt hashes, the password_hash DB field needs to be 255
+#       char long. See update/database/mysql|postgresql/lovestack/2.sql
 HashType=php_default
 # What SiteName should be used when hashing the user_password
 # with the 'md5_site' HashType

--- a/update/database/mysql/lovestack/1.sql
+++ b/update/database/mysql/lovestack/1.sql
@@ -1,3 +1,2 @@
-SET storage_engine=InnoDB;
 UPDATE ezsite_data SET value='lovestack' WHERE name='ezpublish-version';
 UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';

--- a/update/database/mysql/lovestack/1.sql
+++ b/update/database/mysql/lovestack/1.sql
@@ -1,0 +1,3 @@
+SET storage_engine=InnoDB;
+UPDATE ezsite_data SET value='lovestack' WHERE name='ezpublish-version';
+UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';

--- a/update/database/mysql/lovestack/2.sql
+++ b/update/database/mysql/lovestack/2.sql
@@ -1,0 +1,2 @@
+SET storage_engine=InnoDB;
+ALTER TABLE ezuser CHANGE password_hash password_hash VARCHAR(255) default NULL;

--- a/update/database/mysql/lovestack/2.sql
+++ b/update/database/mysql/lovestack/2.sql
@@ -1,2 +1,1 @@
-SET storage_engine=InnoDB;
 ALTER TABLE ezuser CHANGE password_hash password_hash VARCHAR(255) default NULL;

--- a/update/database/postgresql/lovestack/1.sql
+++ b/update/database/postgresql/lovestack/1.sql
@@ -1,0 +1,2 @@
+UPDATE ezsite_data SET value='lovestack' WHERE name='ezpublish-version';
+UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';

--- a/update/database/postgresql/lovestack/2.sql
+++ b/update/database/postgresql/lovestack/2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ezuser ALTER COLUMN password_hash TYPE VARCHAR(255);

--- a/update/run.php
+++ b/update/run.php
@@ -1,0 +1,418 @@
+<?php
+
+/*
+ * Example how to run the script:
+ *
+ *   php update/run.php -u root -h localhost -d ezp
+ *
+ */
+$dbUpdater = new MugoDbUpdater();
+
+$success = $dbUpdater->initConnection();
+
+if( $success )
+{
+    $schemaVersion = $dbUpdater->getDbSchemaVersion();
+
+    if( $schemaVersion )
+    {
+        $sqlFiles = $dbUpdater->getSqlFiles( $schemaVersion );
+
+        if( !empty( $sqlFiles ) )
+        {
+            foreach( $sqlFiles as $versionId => $sqlQueries )
+            {
+                $dbUpdater->log( 'Found DB updates for version: ' . $versionId );
+
+                if( $versionId == $schemaVersion )
+                {
+                    if( !empty( $sqlQueries ) )
+                    {
+                        $dbUpdater->log( ' - Executing DB schema updates' );
+                        $dbUpdater->executeSqlQueries( $sqlQueries, $schemaVersion );
+                    }
+                    else
+                    {
+                        $dbUpdater->log( ' - Could not find any queries in update file.' );
+                    }
+                }
+                else
+                {
+                    $dbUpdater->log( ' - Updates do not match current DB schema version. Current DB schema version: ' . $schemaVersion );
+                }
+            }
+        }
+        else
+        {
+            $dbUpdater->log( 'No SQL un-applied files found' );
+        }
+    }
+
+    $dbUpdater->closeConnection();
+}
+else
+{
+    echo 'Script parameters:' . "\n";
+    echo '-h <db host>' . "\n";
+    echo '-u <db user>' . "\n";
+    echo '-p <db password>' . "\n";
+    echo '-d <db name>' . "\n";
+    echo '-t <db type: mysql | postgresql>' . "\n";
+}
+
+class MugoDbUpdater
+{
+    protected $connection;
+
+    public function initConnection()
+    {
+        $dbOptions = $this->getOptions();
+
+        if( $dbOptions[ 'dbname' ] )
+        {
+            $mysqli = new mysqli(
+                $dbOptions[ 'host' ],
+                $dbOptions[ 'user' ],
+                $dbOptions[ 'pass' ],
+                $dbOptions[ 'dbname' ]
+            );
+
+            if( !$mysqli->connect_error )
+            {
+                $this->connection = $mysqli;
+                return true;
+            }
+            else
+            {
+                echo 'Connect Error (' . $mysqli->connect_errno . ') ' . $mysqli->connect_error . "\n\n";
+            }
+        }
+        else
+        {
+            echo 'Missing DB name parameter "d".' . "\n";
+            echo "\n";
+        }
+
+        return false;
+    }
+
+    public function closeConnection()
+    {
+        $this->connection->close();
+    }
+
+    public function getOptions()
+    {
+        $dbOptions = array();
+
+        $options = getopt( 'h:u:p:d:' );
+        $dbOptions[ 'host' ] = $options[ 'h' ] ?: 'localhost';
+
+        $dbOptions[ 'user' ] = $options[ 'u' ];
+        if( !$dbOptions[ 'user' ] )
+        {
+            $processUser = posix_getpwuid( posix_geteuid() );
+            $dbOptions[ 'user' ] = $processUser[ 'name' ];
+        }
+
+        $dbOptions[ 'pass' ] = isset( $options[ 'p' ] ) ? $options[ 'p' ] : '';
+        $dbOptions[ 'dbname' ] = isset( $options[ 'd' ] ) ? $options[ 'd' ] : '';
+
+        return $dbOptions;
+    }
+
+    public function getDbSchemaVersion()
+    {
+        $return = 0;
+
+        $result = $this->connection->query( 'SELECT value FROM ezsite_data WHERE name="db-schema-version"' );
+
+        if( !$result->num_rows )
+        {
+            $supportedVersions = array(
+                '5.90.0alpha1',
+                '5.4.0alpha1',
+                '5.4.0',
+                '6.12.0',
+            );
+
+            $result = $this->connection->query( 'SELECT value FROM ezsite_data WHERE name="ezpublish-version"' );
+            $row = $result->fetch_row();
+            $ezpVersion = $row[ 0 ];
+
+            if( in_array( $ezpVersion, $supportedVersions ) )
+            {
+                $this->connection->query( 'INSERT INTO ezsite_data SET value = "1", name="db-schema-version"' );
+                $return = 1;
+            }
+            else
+            {
+                echo 'This script is not working for your current ezp version.' . "\n";
+                echo 'Your version: ' . $ezpVersion . "\n";
+                echo 'Supported versions: ' . implode( ', ', $supportedVersions ) . "\n";
+            }
+        }
+        else
+        {
+            $row = $result->fetch_row();
+            $return = $row[ 0 ];
+        }
+
+        return $return;
+    }
+
+    public function getSqlFiles( $schemaVersion )
+    {
+        $sqlFiles = array();
+
+        $directory = 'update/database/mysql/lovestack/';
+        $files = scandir( $directory );
+
+        foreach( $files as $file )
+        {
+            $fullPath = $directory . $file;
+
+            if( is_file( $fullPath ) )
+            {
+                $fileInfo = pathinfo( $file );
+
+                if(
+                    $fileInfo[ 'extension' ] == 'sql' &&
+                    (int) $fileInfo[ 'filename' ] >= $schemaVersion
+                )
+                {
+                    $content = file_get_contents( $fullPath );
+                    $this->remove_comments( $content );
+                    $content = $this->remove_remarks( $content );
+
+                    $sqlFiles[ $fileInfo[ 'filename' ] ] = $this->split_sql_file( $content, ';' );
+                }
+            }
+        }
+
+        ksort( $sqlFiles );
+
+        return $sqlFiles;
+    }
+
+    public function log( $message )
+    {
+        echo $message . "\n";
+    }
+
+    /**
+     * @param $sqlQueries
+     * @param $schemaVersion
+     * @return boolean
+     */
+    public function executeSqlQueries( $sqlQueries, $schemaVersion )
+    {
+        $allQueriesOK = true;
+
+        // In most cases the transaction will not fully rollback
+        // due to implicit commits by mysql:
+        // https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html
+        $this->connection->autocommit( false );
+        {
+            foreach( $sqlQueries as $query )
+            {
+                $query = trim( $query );
+
+                $result = $this->connection->query( $query );
+
+                if( !$result )
+                {
+                    $this->log( 'Failed to execute query "' . trim( $query ) . '". Error:' );
+                    $this->log( $this->connection->error );
+
+                    $allQueriesOK = false;
+                    break;
+                }
+            }
+        }
+
+        if( $allQueriesOK )
+        {
+            $this->connection->commit();
+            $this->connection->autocommit( true );
+
+            // increase DB schema version
+            $schemaVersion = $schemaVersion + 1;
+            $this->connection->query( 'UPDATE ezsite_data SET value="'. (int) $schemaVersion .'" WHERE name="db-schema-version"' );
+            $this->log( 'New DB schema version is: ' . (int) $schemaVersion );
+        }
+        else
+        {
+            $this->connection->rollback();
+        }
+
+        return $allQueriesOK;
+    }
+
+    /*
+     * parse sql file
+     */
+    public function remove_comments( &$output )
+    {
+        $lines = explode("\n", $output);
+        $output = "";
+
+        // try to keep mem. use down
+        $linecount = count($lines);
+
+        $in_comment = false;
+        for($i = 0; $i < $linecount; $i++)
+        {
+            if( preg_match("/^\/\*/", preg_quote($lines[$i])) )
+            {
+                $in_comment = true;
+            }
+
+            if( !$in_comment )
+            {
+                $output .= $lines[$i] . "\n";
+            }
+
+            if( preg_match("/\*\/$/", preg_quote($lines[$i])) )
+            {
+                $in_comment = false;
+            }
+        }
+
+        unset($lines);
+        return $output;
+    }
+
+    /**
+     * remove_remarks will strip the sql comment lines out of an uploaded sql file
+     *
+     * @param $sql
+     * @return string
+     */
+    public function remove_remarks( $sql )
+    {
+        $lines = explode("\n", $sql);
+
+        // try to keep mem. use down
+        $sql = "";
+
+        $linecount = count($lines);
+        $output = "";
+
+        for ($i = 0; $i < $linecount; $i++)
+        {
+            if (($i != ($linecount - 1)) || (strlen($lines[$i]) > 0))
+            {
+                if (isset($lines[$i][0]) && $lines[$i][0] != "#")
+                {
+                    $output .= $lines[$i] . "\n";
+                }
+                else
+                {
+                    $output .= "\n";
+                }
+                // Trading a bit of speed for lower mem. use here.
+                $lines[$i] = "";
+            }
+        }
+
+        return $output;
+
+    }
+
+    /**
+     * split_sql_file will split an uploaded sql file into single sql statements.
+     * Note: expects trim() to have already been run on $sql.
+     *
+     * @param $sql
+     * @param $delimiter
+     * @return array
+     */
+    public function split_sql_file($sql, $delimiter)
+    {
+        // Split up our string into "possible" SQL statements.
+        $tokens = explode($delimiter, $sql);
+
+        // try to save mem.
+        $sql = "";
+        $output = array();
+
+        // we don't actually care about the matches preg gives us.
+        $matches = array();
+
+        // this is faster than calling count($oktens) every time thru the loop.
+        $token_count = count($tokens);
+        for ($i = 0; $i < $token_count; $i++)
+        {
+            // Don't wanna add an empty string as the last thing in the array.
+            if (($i != ($token_count - 1)) || (strlen($tokens[$i] > 0)))
+            {
+                // This is the total number of single quotes in the token.
+                $total_quotes = preg_match_all("/'/", $tokens[$i], $matches);
+                // Counts single quotes that are preceded by an odd number of backslashes,
+                // which means they're escaped quotes.
+                $escaped_quotes = preg_match_all("/(?<!\\\\)(\\\\\\\\)*\\\\'/", $tokens[$i], $matches);
+
+                $unescaped_quotes = $total_quotes - $escaped_quotes;
+
+                // If the number of unescaped quotes is even, then the delimiter did NOT occur inside a string literal.
+                if (($unescaped_quotes % 2) == 0)
+                {
+                    // It's a complete sql statement.
+                    $output[] = $tokens[$i];
+                    // save memory.
+                    $tokens[$i] = "";
+                }
+                else
+                {
+                    // incomplete sql statement. keep adding tokens until we have a complete one.
+                    // $temp will hold what we have so far.
+                    $temp = $tokens[$i] . $delimiter;
+                    // save memory..
+                    $tokens[$i] = "";
+
+                    // Do we have a complete statement yet?
+                    $complete_stmt = false;
+
+                    for ($j = $i + 1; (!$complete_stmt && ($j < $token_count)); $j++)
+                    {
+                        // This is the total number of single quotes in the token.
+                        $total_quotes = preg_match_all("/'/", $tokens[$j], $matches);
+                        // Counts single quotes that are preceded by an odd number of backslashes,
+                        // which means they're escaped quotes.
+                        $escaped_quotes = preg_match_all("/(?<!\\\\)(\\\\\\\\)*\\\\'/", $tokens[$j], $matches);
+
+                        $unescaped_quotes = $total_quotes - $escaped_quotes;
+
+                        if (($unescaped_quotes % 2) == 1)
+                        {
+                            // odd number of unescaped quotes. In combination with the previous incomplete
+                            // statement(s), we now have a complete statement. (2 odds always make an even)
+                            $output[] = $temp . $tokens[$j];
+
+                            // save memory.
+                            $tokens[$j] = "";
+                            $temp = "";
+
+                            // exit the loop.
+                            $complete_stmt = true;
+                            // make sure the outer loop continues at the right point.
+                            $i = $j;
+                        }
+                        else
+                        {
+                            // even number of unescaped quotes. We still don't have a complete statement.
+                            // (1 odd and 1 even always make an odd)
+                            $temp .= $tokens[$j] . $delimiter;
+                            // save memory.
+                            $tokens[$j] = "";
+                        }
+
+                    } // for..
+                } // else
+            }
+        }
+
+        return $output;
+    }
+}

--- a/update/run.php
+++ b/update/run.php
@@ -32,7 +32,7 @@ if( $success )
                     if( !empty( $sqlQueries ) )
                     {
                         $dbUpdater->log( ' - Executing DB schema updates' );
-                        $dbUpdater->executeSqlQueries( $sqlQueries, $schemaVersion );
+                        $schemaVersion = $dbUpdater->executeSqlQueries( $sqlQueries, $schemaVersion );
                     }
                     else
                     {
@@ -184,7 +184,7 @@ class MugoDbUpdater
     /**
      * @param $sqlQueries
      * @param $schemaVersion
-     * @return boolean
+     * @return integer
      */
     public function executeSqlQueries( $sqlQueries, $schemaVersion )
     {
@@ -227,7 +227,7 @@ class MugoDbUpdater
             $this->connection->rollback();
         }
 
-        return $allQueriesOK;
+        return $schemaVersion;
     }
 
     /*


### PR DESCRIPTION
**DB schema manager**
We recently merged a pull request that contained DB schema changes: #74.
It's the first time we introduce DB schema changes in our fork. And it raises the question about how to make sure that we have an easy upgrade path for the fork. In this comment we discussed a solution:
https://github.com/mugoweb/ezpublish-legacy/pull/74#issuecomment-340562978

Basically, we want to rely on a DB schema version ID. And have all DB schema changes require a specific schema version ID and once they are successfully applied, the schema version ID will raise by 1.

This pull request contains a PHP script that handles the DB schema updates. The idea is that you can place any schema updates instructions (written in SQL) into a file and place it under:
update/database/mysql/lovestack/<versionID>.sql

In this pull request, we have 2 files containing changes to the DB schema:
1.sql
2.sql

In future pull request that do require DB schema changes, you would create a file called:
3.sql

The PHP script that handles the DB schema update (update/run.php) will automatically pick up the relevant files and will apply the DB schema changes. So if the current schema version in your installation is 3, it will execute the 3.sql script. If you run the script a second time, it would not execute any DB schema changes -- the current schema version is 4 and there is not file called 4.sql. So you can always run the update/run.php script to make sure you have the most recent DB schema -- even if it might not need to do any updates at all.

**postgreSQL support**
Currently the script does not support postgreSQL DB servers. But I wrote the script in a way that we can easily add support for it later. There is a class MugoDbUpdater containing functions that can communicate with a mysql server. The child class MugoDbUpdaterPostgresql is only a stub. By overwriting a few functions, you can make sure that the run.php script would support postgreSQL DB servers. I already implemented the function initConnection as an example.
We should decide if it's worth supporting postgreSQL at all.

**Naming the fork**
I started to use the name 'lovestack' in the codebase now. If you have concerns about the name, we should consider another name/label.

**Note in ini**
The site.ini now has a note that you need to update the schema for the new password hash generation.

**Script parameters**
-h <db host>
-u <db user>
-p <db password>
-d <db name>
-t <db type: mysql | postgresql>

The script will dump out the parameters if it you missed a required parameter (-d) or was not able to connect to your DB.

**Upgrade path**
In order to run this script on an older ezp installation, you would need to upgrade to ezp 5.4 first. Otherwise the script will execute any DB schema updates.

**Further improvement**
I see a lot of potential further improvements, like:
- logging to a file
- logging successful and un-successful SQL statements
- better inline documentation
- support upgrade scripts

But I hope we can start soon with a basic working version for this script.