### PR TITLE
Forward the session remove function call to the session handler

### DIFF
--- a/lib/ezsession/classes/ezpsessionhandlerphp.php
+++ b/lib/ezsession/classes/ezpsessionhandlerphp.php
@@ -49,16 +49,13 @@ class ezpSessionHandlerPHP extends ezpSessionHandler
         return false;
     }
 
-    /**
-     *  reimp (not used in this handler)
-     *
-     *  So callbacks on this function is not called, this is a known limitation.
-     *  Either make sure your data does not depend on session id, or make sure it is cleanup in session_gc.php (cronjob).
-     */
     public function destroy( $sessionId )
     {
+        $_SESSION = array();
+        session_destroy();
+
         ezpEvent::getInstance()->notify( 'session/destroy', array( $sessionId ) );
-        return false;
+        return true;
     }
 
     /**

--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -512,12 +512,14 @@ class eZSession
         {
              return false;
         }
-        $_SESSION = array();
-        session_destroy();
+
+        $result = self::getHandlerInstance()->destroy( session_id() );
+
         self::$hasStarted = false;
-        self::$handlerInstance = null;
-        return true;
-    }
+		self::$handlerInstance = null;
+
+		return $result;
+	}
 
     /**
      * Sets the current userID used by ezpSessionHandlerDB::write() on shutdown.

--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -516,10 +516,10 @@ class eZSession
         $result = self::getHandlerInstance()->destroy( session_id() );
 
         self::$hasStarted = false;
-		self::$handlerInstance = null;
+        self::$handlerInstance = null;
 
-		return $result;
-	}
+        return $result;
+    }
 
     /**
      * Sets the current userID used by ezpSessionHandlerDB::write() on shutdown.


### PR DESCRIPTION
In ezp there is a *session wrapper*:
https://github.com/mugoweb/ezpublish-legacy/blob/master/lib/ezsession/classes/ezsession.php

It has functions like `start`, `regenerate`, `remove` etc.

Those function calls get forwarded to a concrete *session handler* - for example:
https://github.com/mugoweb/ezpublish-legacy/blob/master/lib/ezsession/classes/ezpsessionhandlerphp.php

This *session handler* is using the default PHP sessions. But there are also other handlers like a DB handler, storing the session in the DB:
https://github.com/mugoweb/ezpublish-legacy/blob/master/lib/ezsession/classes/ezpsessionhandlerdb.php

The *session wrapper* class is not always forwarding the function calls to the handler class. The function `remove` has concrete code to remove a PHP session. That code should be in ezpsessionhandlerphp.php.

This pull request fixing that.

The pull request is hard to test because ezp is not really using the `remove` function of the session wrapper. If a visitor logs our, the system is just regenerating a new (and empty) session (which is another problem - but let's ignore that for now). 

Only `ezscript.php` is calling eZSession::remove(). So here is a way **how to test this pull request**:

1) Check the PHP configuration to see in which directory the session files are stored on the web server: "php -i | grep session.save_path"
2) Clear all files in that directory (ONLY DO THIS ON A TESTING SERVER)
3) Run php bin/php/updatesearchindex.php
4) That script will generate a session id in that directory.
5) Once the script is done it will delete the session file in the directory - so if you're not quick enough you won't see the session file at all.

If you like you can test this with other session handlers as well - like the DB session handler.
