### PR TITLE
ezselection view template was rendering to many line breaks

### DIFF
--- a/design/standard/templates/content/datatype/view/ezselection.tpl
+++ b/design/standard/templates/content/datatype/view/ezselection.tpl
@@ -2,8 +2,7 @@
 {let selected_id_array=$attribute.content}
 {foreach $attribute.class_content.options as $Options}
     {if $selected_id_array|contains( $Options.id )}
-        {$Options.name|wash( xhtml )}
+        {$Options.name|wash( xhtml )}<br />
     {/if}
-    {delimiter}<br/>{/delimiter}
 {/foreach}
 {/let}


### PR DESCRIPTION
In https://github.com/mugoweb/ezpublish-legacy/pull/63 I introduced a regression bug. The template is rendering too many line breaks (<br />).
