### PR TITLE
Display all version info available in setup/info view

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ eZ Publish is database, platform and browser independent. Because it is
 browser based it can be used and updated from anywhere as long as you have
 access to the Internet.
 
+Installation
+------------
+Read doc/INSTALL or go to http://doc.ez.no/eZ-Publish
+
+How to upgrade and use the lovestack version
+--
+The eZ Publish upgrade process and how you can switch to
+the lovestack is documented in [update/README.md](update/README.md)
 
 License
 -------
@@ -69,11 +77,6 @@ Main eZ Publish features
     - wysiwyg rich-text editor
     - in-site content editing
     - content geolocation
-
-
-Installation
-------------
-Read doc/INSTALL or go to http://doc.ez.no/eZ-Publish
 
 
 Issue tracker

--- a/design/admin/templates/setup/info.tpl
+++ b/design/admin/templates/setup/info.tpl
@@ -24,8 +24,24 @@
     </div>
 
     <div class="block">
-        <label>{'Version'|i18n( 'design/admin/setup/info', 'eZ Publish version' )}:</label>
+        <label>{'Code version'|i18n( 'design/admin/setup/info', 'eZ Publish version' )}:</label>
         {$ezpublish_version}
+    </div>
+    <div class="block">
+        <label>{'Edition'|i18n( 'design/admin/setup/info', 'eZ Publish edition' )}:</label>
+        {$ezpublish_edition}
+    </div>
+    <div class="block">
+        <label>{'Database version'|i18n( 'design/admin/setup/info' )}:</label>
+        {$ezpublish_db_version}
+    </div>
+    <div class="block">
+        <label>{'Database version release'|i18n( 'design/admin/setup/info' )}:</label>
+        {$ezpublish_db_version_release}
+    </div>
+    <div class="block">
+        <label>{'Database schema version'|i18n( 'design/admin/setup/info' )}:</label>
+        {$ezpublish_schema_version}
     </div>
 
     <div class="block">

--- a/design/admin/templates/setup/info.tpl
+++ b/design/admin/templates/setup/info.tpl
@@ -23,6 +23,12 @@
         {ezini('SiteSettings','SiteURL')}
     </div>
 
+    {if $ezpublish_commit_hash}
+        <div class="block">
+            <label>{'Last commit hash'|i18n( 'design/admin/setup/info', 'eZ Publish version' )}:</label>
+            <a href="https://github.com/mugoweb/ezpublish-legacy/commits/{$ezpublish_commit_hash}">{$ezpublish_commit_hash}</a>
+        </div>
+    {/if}
     <div class="block">
         <label>{'Code version'|i18n( 'design/admin/setup/info', 'eZ Publish version' )}:</label>
         {$ezpublish_version}
@@ -30,14 +36,6 @@
     <div class="block">
         <label>{'Edition'|i18n( 'design/admin/setup/info', 'eZ Publish edition' )}:</label>
         {$ezpublish_edition}
-    </div>
-    <div class="block">
-        <label>{'Database version'|i18n( 'design/admin/setup/info' )}:</label>
-        {$ezpublish_db_version}
-    </div>
-    <div class="block">
-        <label>{'Database version release'|i18n( 'design/admin/setup/info' )}:</label>
-        {$ezpublish_db_version_release}
     </div>
     <div class="block">
         <label>{'Database schema version'|i18n( 'design/admin/setup/info' )}:</label>

--- a/design/standard/templates/setup/info.tpl
+++ b/design/standard/templates/setup/info.tpl
@@ -9,14 +9,13 @@
     <tr>
         <td><p><b>{'Site'|i18n('design/standard/setup')}:</b></p></td><td><p>{ezini('SiteSettings','SiteURL')}</p></td>
     </tr>
+    {if $ezpublish_commit_hash}
+        <tr>
+            <td><p><b>{'Last commit hash'|i18n('design/standard/setup','eZ Publish version')}</b></p></td><td><p><a href="https://github.com/mugoweb/ezpublish-legacy/commits/{$ezpublish_commit_hash}">{$ezpublish_commit_hash}</a></p></td>
+        </tr>
+    {/if}
     <tr>
         <td><p><b>{'Code version'|i18n('design/standard/setup','eZ Publish version')}</b></p></td><td><p>{$ezpublish_version}</p></td>
-    </tr>
-    <tr>
-        <td><p><b>{'Database version'|i18n('design/standard/setup','eZ Publish DB version')}</b></p></td><td><p>{$ezpublish_db_version}</p></td>
-    </tr>
-    <tr>
-        <td><p><b>{'Database version release'|i18n('design/standard/setup','DB version release')}</b></p></td><td><p>{$ezpublish_db_version_release}</p></td>
     </tr>
     <tr>
         <td><p><b>{'Database schema version'|i18n('design/standard/setup','DB schema version')}</b></p></td><td><p>{$ezpublish_schema_version}</p></td>

--- a/design/standard/templates/setup/info.tpl
+++ b/design/standard/templates/setup/info.tpl
@@ -10,7 +10,16 @@
         <td><p><b>{'Site'|i18n('design/standard/setup')}:</b></p></td><td><p>{ezini('SiteSettings','SiteURL')}</p></td>
     </tr>
     <tr>
-        <td><p><b>{'Version'|i18n('design/standard/setup','eZ Publish version')}</b></p></td><td><p>{$ezpublish_version}</p></td>
+        <td><p><b>{'Code version'|i18n('design/standard/setup','eZ Publish version')}</b></p></td><td><p>{$ezpublish_version}</p></td>
+    </tr>
+    <tr>
+        <td><p><b>{'Database version'|i18n('design/standard/setup','eZ Publish DB version')}</b></p></td><td><p>{$ezpublish_db_version}</p></td>
+    </tr>
+    <tr>
+        <td><p><b>{'Database version release'|i18n('design/standard/setup','DB version release')}</b></p></td><td><p>{$ezpublish_db_version_release}</p></td>
+    </tr>
+    <tr>
+        <td><p><b>{'Database schema version'|i18n('design/standard/setup','DB schema version')}</b></p></td><td><p>{$ezpublish_schema_version}</p></td>
     </tr>
     <tr>
         <td><p><b>{'Extensions'|i18n('design/standard/setup','eZ Publish extensions')}</b></p></td>

--- a/kernel/setup/info.php
+++ b/kernel/setup/info.php
@@ -76,6 +76,7 @@ if ( function_exists( 'apache_get_version' ) )
         $webserverInfo['modules'] = apache_get_modules();
 }
 
+$tpl->setVariable( 'ezpublish_commit_hash', eZPublishSDK::GIT_COMMIT_HASH );
 $tpl->setVariable( 'ezpublish_version', eZPublishSDK::version() . " (" . eZPublishSDK::VERSION_ALIAS . ")" );
 $tpl->setVariable( 'ezpublish_edition', eZPublishSDK::EDITION );
 $tpl->setVariable( 'ezpublish_db_version', eZSiteData::fetchByName( 'ezpublish-version' )->value );

--- a/kernel/setup/info.php
+++ b/kernel/setup/info.php
@@ -76,7 +76,11 @@ if ( function_exists( 'apache_get_version' ) )
         $webserverInfo['modules'] = apache_get_modules();
 }
 
-$tpl->setVariable( 'ezpublish_version', eZPublishSDK::version() . " (" . eZPublishSDK::alias() . ")" );
+$tpl->setVariable( 'ezpublish_version', eZPublishSDK::version() . " (" . eZPublishSDK::VERSION_ALIAS . ")" );
+$tpl->setVariable( 'ezpublish_edition', eZPublishSDK::EDITION );
+$tpl->setVariable( 'ezpublish_db_version', eZSiteData::fetchByName( 'ezpublish-version' )->value );
+$tpl->setVariable( 'ezpublish_db_version_release', eZSiteData::fetchByName( 'ezpublish-release' )->value );
+$tpl->setVariable( 'ezpublish_schema_version', eZSiteData::fetchByName( 'db-schema-version' )->value );
 $tpl->setVariable( 'ezpublish_extensions', eZExtension::activeExtensions() );
 $tpl->setVariable( 'php_version', phpversion() );
 $tpl->setVariable( 'php_accelerator', $phpAcceleratorInfo );

--- a/lib/version.php
+++ b/lib/version.php
@@ -14,13 +14,13 @@
 
 class eZPublishSDK
 {
-    const VERSION_MAJOR = 5;
-    const VERSION_MINOR = 90;
+    const VERSION_MAJOR = 1;
+    const VERSION_MINOR = 0;
     const VERSION_RELEASE = 0;
-    const VERSION_STATE = 'alpha1';
+    const VERSION_STATE = 'master';
     const VERSION_DEVELOPMENT = true;
-    const VERSION_ALIAS = '5.90';
-    const EDITION = 'eZ Publish Community Project';
+    const VERSION_ALIAS = 'lovestack';
+    const EDITION = 'Lovestack Edition';
 
     /*!
       \return the SDK version as a string

--- a/lib/version.php
+++ b/lib/version.php
@@ -14,6 +14,7 @@
 
 class eZPublishSDK
 {
+    const GIT_COMMIT_HASH = '';
     const VERSION_MAJOR = 1;
     const VERSION_MINOR = 0;
     const VERSION_RELEASE = 0;

--- a/update/README.md
+++ b/update/README.md
@@ -1,8 +1,8 @@
 Upgrading a lovestack installation
 =
-The lovestack is a fork of the eZPublish legacy
+The lovestack is a fork of the eZ Publish legacy
 project. This document describes the process of
-upgrade from a eZPublish legacy version to the
+upgrade from an eZ Publish legacy version to the
 latest lovestack version.
 If you already use the lovestack and just want
 to upgrade to the latest version you should look
@@ -10,20 +10,18 @@ at _Upgrading to the latest version of the lovestack_
 
 General notes
 ==
-Consider to make a backup of your installation. That
+Consider making a backup of your installation. That
 includes your current code version, your database content
 and your content in the var folder (assets like images etc).
 
 
-Upgrading from an eZPublish legacy version
+Upgrading from an eZ Publish legacy version
 ==
-Before you can use the lovestack version you have
-to make sure that you upgrade your eZPublish legacy
-installation to the version 5.4.x
+Before you can use the lovestack version you need
+upgrade your eZ Publish legacy installation to the version 5.4.x
 
-The upgrade path is documented until version 5.2. You
-find the documentation here:
-https://doc.ez.no/eZ-Publish/Upgrading
+The upgrade path is documented until version 5.2. You can
+find the documentation here: https://doc.ez.no/eZ-Publish/Upgrading
 
 Further upgrade from 5.2 to 5.4 is documented here:
 https://doc.ez.no/display/EZP/Updating
@@ -47,7 +45,7 @@ This instruction assumes that you have an existing ezp
 publish installation on your system (for example under
 _/var/www/ezp_).
 It also assumes that you developed all your customizations
-in custom ezpublish extension and that all changes to settings
+in a custom eZ Publish extension and that all changes to settings
 are under the _override_ folder or under a _siteaccess_ folder.
 
 
@@ -71,9 +69,9 @@ php update/run.php #In order to get the help screen
 php update/run.php <parameters> #provide the necessary parameters
 ```
 
-Store the commit hash into eZPublish. It will allow you
+Store the commit hash in eZ Publish. It will allow you
 to always check what code version of the lovestack you're
-running. You get the commit has with the command `git rev-parse HEAD`.
+running. You get the commit hash with the command `git rev-parse HEAD`.
 That hash string needs to be added to `lib/version.php`.
 
 ```
@@ -88,7 +86,7 @@ php bin/php/ezpgenerateautoloads.php -e
 php bin/php/ezcache.php --clear-all
 ```
 
-The upgrade process is now done. In case you installation is
+The upgrade process is now done. In case your installation is
 connected to a code repository, you can now commit the changes
 to that repository.
 
@@ -104,7 +102,7 @@ Notes about legacy_2018 extension
 ==
 The lovestack fork has an eZ Publish extension called _legacy_2018_.
 It contains features that are considered old and unwanted in the
-core system of ezpublish ( _kernel_ or _lib_ feature). In most cases
+core system of eZ Publish ( _kernel_ or _lib_ feature). In most cases
 you don't want to enable this extension unless your project depends
-on the feature that is no located in the extension. See the extension
+on the feature that is now located in the extension. See the extension
 README.md file for more details

--- a/update/README.md
+++ b/update/README.md
@@ -1,0 +1,110 @@
+Upgrading a lovestack installation
+=
+The lovestack is a fork of the eZPublish legacy
+project. This document describes the process of
+upgrade from a eZPublish legacy version to the
+latest lovestack version.
+If you already use the lovestack and just want
+to upgrade to the latest version you should look
+at _Upgrading to the latest version of the lovestack_
+
+General notes
+==
+Consider to make a backup of your installation. That
+includes your current code version, your database content
+and your content in the var folder (assets like images etc).
+
+
+Upgrading from an eZPublish legacy version
+==
+Before you can use the lovestack version you have
+to make sure that you upgrade your eZPublish legacy
+installation to the version 5.4.x
+
+The upgrade path is documented until version 5.2. You
+find the documentation here:
+https://doc.ez.no/eZ-Publish/Upgrading
+
+Further upgrade from 5.2 to 5.4 is documented here:
+https://doc.ez.no/display/EZP/Updating
+
+You only have to upgrade your eZ Publish legacy installation.
+There is no need to setup the eZ Publish "new stack".
+
+If you don't have access to the ezp releases and use
+the code from the git repository you want to make sure
+to upgrade until you reach the 2017.08.1.1 release version:
+https://github.com/ezsystems/ezpublish-legacy/releases/tag/v2017.08.1.1
+Do not upgrade to a newer eZ Publish release.
+
+After this upgrade you need to follow the instructions of
+_Upgrading to the latest version of the lovestack_.
+
+Upgrading to the latest version of the lovestack
+==
+
+This instruction assumes that you have an existing ezp
+publish installation on your system (for example under
+_/var/www/ezp_).
+It also assumes that you developed all your customizations
+in custom ezpublish extension and that all changes to settings
+are under the _override_ folder or under a _siteaccess_ folder.
+
+
+Clone the lovestack code repository in a separate directory
+```
+cd /tmp
+git clone https://github.com/mugoweb/ezpublish-legacy.git
+```
+
+Override your installation with the new code version
+```
+rsync -auv /tmp/ezpublish-legacy/* /var/www/ezp
+```
+
+Run the DB update script to make sure you have the
+latest DB schema version. The script needs the correct
+parameters in order to know how to connect to your DB.
+```
+cd /var/www/ezp
+php update/run.php #In order to get the help screen
+php update/run.php <parameters> #provide the necessary parameters
+```
+
+Store the commit hash into eZPublish. It will allow you
+to always check what code version of the lovestack you're
+running. You get the commit has with the command `git rev-parse HEAD`.
+That hash string needs to be added to `lib/version.php`.
+
+```
+cd /tmp/ezpublish-legacy
+sed -i "/const GIT_COMMIT_HASH = '.*';/c\    const GIT_COMMIT_HASH = '$(git rev-parse HEAD)';" /var/www/ezp/lib/version.php
+```
+
+Now rebuild the autoload map and clear the cache
+```
+cd /var/www/ezp
+php bin/php/ezpgenerateautoloads.php -e
+php bin/php/ezcache.php --clear-all
+```
+
+The upgrade process is now done. In case you installation is
+connected to a code repository, you can now commit the changes
+to that repository.
+
+Notes about zeta components
+==
+eZ Publish decided to rely on the zeta components being installed
+in the vendor directory. That is the case if you install/upgrade
+the eZ Publish version with composer. Previous versions of eZ Publish
+supported a zeta component installation in different locations on
+the system.
+
+Notes about legacy_2018 extension
+==
+The lovestack fork has an eZ Publish extension called _legacy_2018_.
+It contains features that are considered old and unwanted in the
+core system of ezpublish ( _kernel_ or _lib_ feature). In most cases
+you don't want to enable this extension unless your project depends
+on the feature that is no located in the extension. See the extension
+README.md file for more details


### PR DESCRIPTION
This pull request is doing 2 things:

1) Version information
There are a few version information in ezp and it's a bit confusion. The assembla ticket 535 is discussing the issue. This branch is for code relevant changes.
The 'System Information' page (under Setup in the admin interface) now shows following version info:

Last commit hash: _12312df87_ (with link to github history until this commit)
Code version:   _1.0.0master (lovestack)_
Edition:  _Lovestack Edition_
Database schema version: _3_

2) A new README.md file under update
That document describes how to switch to the _lovestack_ fork and also how to update to the latest version of the _lovestack_
