### PR TITLE
Typo in variable name results in PHP Notice and unneeded file deletion checks on ezbinaryfile store/publish.

### DIFF
--- a/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
+++ b/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
@@ -332,8 +332,8 @@ class eZBinaryFileType extends eZDataType
             else
             {
                 // if storing a different file for the same version, see if the existing file can be removed.
-                $newfilename = basename( $httpBinaryFile->attribute( "filename" ) );
-                if ( $newFilename != $binary->Filename )
+                $newFileName = basename( $httpBinaryFile->attribute( "filename" ) );
+                if ( $newFileName != $binary->Filename )
                 {
                     $this->deleteStoredObjectAttribute( $contentObjectAttribute, $version );
                 }


### PR DESCRIPTION
Pull request from upstream:
https://github.com/ezsystems/ezpublish-legacy/pull/1347