### PR TITLE
[Feature] Change to use Composer for autoload, drop PEAR/EZC

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -19,54 +19,27 @@ if ( file_exists( __DIR__ . '/config.php' ) )
     require_once __DIR__ . '/config.php';
 }
 
+// Check for EZCBASE_ENABLED, if set we can skip autoloading Zeta Components
 if ( !defined( 'EZCBASE_ENABLED' ) )
 {
-    $defaultAppName = "app";
-    if ( !file_exists( __DIR__ . "/../$defaultAppName" ) )
-    {
-        $defaultAppName = "ezpublish";
-    }
+    // Start by setting EZCBASE_ENABLED to avoid recursion
+    define( 'EZCBASE_ENABLED', false );
 
-    $appName = defined( 'EZP_APP_FOLDER_NAME' ) ? EZP_APP_FOLDER_NAME : $defaultAppName;
-    $appFolder = __DIR__ . "/../$appName";
-    $legacyVendorDir = __DIR__ . "/vendor";
-
-    // Bundled
-    if ( defined( 'EZP_USE_BUNDLED_COMPONENTS' ) ? EZP_USE_BUNDLED_COMPONENTS === true : file_exists( __DIR__ . "/lib/ezc" ) )
+    // If composer autoloader is already present we can skip trying to load it
+    if ( class_exists( 'Composer\Autoload\ClassLoader', false ) )
     {
-        set_include_path( __DIR__ . PATH_SEPARATOR . __DIR__ . "/lib/ezc" . PATH_SEPARATOR . get_include_path() );
-        require 'Base/src/base.php';
-        $baseEnabled = true;
+        // do nothing
     }
-    // Custom config.php defined
-    else if ( defined( 'EZC_BASE_PATH' ) )
+    // Composer if in eZ Platform context
+    else if ( file_exists( __DIR__ . "/../vendor/autoload.php" ) )
     {
-        require EZC_BASE_PATH;
-        $baseEnabled = true;
-    }
-    // Composer if in eZ Publish5 context
-    else if ( strpos( $appFolder, "{$appName}/../{$appName}" ) === false && file_exists( "{$appFolder}/autoload.php" ) )
-    {
-        require_once "{$appFolder}/autoload.php";
-        $baseEnabled = false;
+        require_once __DIR__ . "/../vendor/autoload.php";
     }
     // Composer if in eZ Publish legacy context
-    else if ( file_exists( "{$legacyVendorDir}/autoload.php" ) )
+    else if ( file_exists( __DIR__ . "/vendor/autoload.php" ) )
     {
-        require_once "{$legacyVendorDir}/autoload.php";
-        $baseEnabled = false;
+        require_once __DIR__ . "/vendor/autoload.php";
     }
-    // PEAR install
-    else
-    {
-        $baseEnabled = @include 'ezc/Base/base.php';
-        if ( !$baseEnabled )
-        {
-            $baseEnabled = @include 'Base/src/base.php';
-        }
-    }
-
-    define( 'EZCBASE_ENABLED', $baseEnabled );
 }
 
 // Check if ezpAutoloader exists because it can be already declared if running in the Symfony context (e.g. CLI scripts)

--- a/bin/php/ezpgenerateautoloads.php
+++ b/bin/php/ezpgenerateautoloads.php
@@ -16,52 +16,22 @@ if ( file_exists( "config.php" ) )
 
 // Setup, includes
 //{
-$defaultAppName = "app";
-if ( !file_exists( __DIR__ . "/../../../$defaultAppName" ) )
-{
-    $defaultAppName = "ezpublish";
-}
 
-$appName = defined( 'EZP_APP_FOLDER_NAME' ) ? EZP_APP_FOLDER_NAME : $defaultAppName;
-$appFolder = getcwd() . "/../$appName";
+$platformVendorDir = getcwd() . "/../vendor";
 $legacyVendorDir = getcwd() . "/vendor";
-
-$baseEnabled = true;
-// Bundled
-if ( defined( 'EZP_USE_BUNDLED_COMPONENTS' ) ? EZP_USE_BUNDLED_COMPONENTS === true : file_exists( 'lib/ezc' ) )
+if ( class_exists( 'Composer\Autoload\ClassLoader', false ) )
 {
-    set_include_path( './lib/ezc' . PATH_SEPARATOR . get_include_path() );
-    require 'Base/src/base.php';
+    // Do nothing, composer autoload already loaded
 }
-// Custom config.php defined
-else if ( defined( 'EZC_BASE_PATH' ) )
+// Composer if in eZ Platform context
+else if ( file_exists( "{$platformVendorDir}/autoload.php" ) )
 {
-    require EZC_BASE_PATH;
-}
-// Composer if in eZ Publish5 context
-else if ( strpos( $appFolder, "{$appName}/../{$appName}" ) === false && file_exists( "{$appFolder}/autoload.php" ) )
-{
-    require_once "{$appFolder}/autoload.php";
-    $baseEnabled = false;
+    require_once "{$platformVendorDir}/autoload.php";
 }
 // Composer if in eZ Publish legacy context
 else if ( file_exists( "{$legacyVendorDir}/autoload.php" ) )
 {
     require_once "{$legacyVendorDir}/autoload.php";
-    $baseEnabled = false;
-}
-// PEAR
-else
-{
-    if ( !@include 'ezc/Base/base.php' )
-    {
-        require 'Base/src/base.php';
-    }
-}
-
-if ( $baseEnabled )
-{
-    spl_autoload_register( array( 'ezcBase', 'autoload' ) );
 }
 
 require 'kernel/private/classes/ezautoloadgenerator.php';

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,20 @@
         "phpunit/phpunit": "3.7.*",
         "zetacomponents/php-generator": "~1.1"
     },
+    "autoload": {
+      "files": ["autoload.php"]
+    },
+    "scripts": {
+      "legacy-scripts": [
+          "@php bin/php/ezpgenerateautoloads.php"
+      ],
+      "post-install-cmd": [
+          "@legacy-scripts"
+      ],
+      "post-update-cmd": [
+          "@legacy-scripts"
+      ]
+    },
     "conflict": {
         "ezsystems/ezpublish-kernel": "<6.12 || >=2014.11 <2017.10"
     },

--- a/config.php-RECOMMENDED
+++ b/config.php-RECOMMENDED
@@ -12,46 +12,6 @@
    *uncomment* the proposed settings.
 */
 
-
-/*
-   PATH TO THE EZCOMPONENTS
-   ------------------------
-   config.php can set the components path like:
-*/
-//ini_set( 'include_path', ini_get( 'include_path' ). PATH_SEPARATOR . '../ezcomponents/trunk' );
-
-/*
-    USING COMPONENTS VIA COMPOSER
-    -----------------------------
-    If installation is in a eZ Publish 5/Symfony context, composer will be attempted to be used
-    if the following file is found: '../EZP_APP_FOLDER_NAME/autoload.php'
-    Default EZP_APP_FOLDER_NAME value is "app" and this constant gives you possibility to change it.
-    In eZ Publish 5.x, default value of EZP_APP_FOLDER_NAME was "ezpublish".
-*/
-//define( 'EZP_APP_FOLDER_NAME', 'my_app' );
-
-/*
-    USING BUNDLED COMPONENTS
-    ------------------------
-    If you are using a distribution of eZ Publish with which the necessary
-    eZ Components are bundled (in lib/ezc), then you can use this setting to
-    control if the bundled eZ Components should be used (true) or not (false).
-    By default, when this setting is not present and the bundled eZ Components are
-    present, they will be used. If you're using the bundled eZ Components it's recommended
-    to define EZP_USE_BUNDLED_COMPONENTS as a boolean true anyway, for optimal speed.
-*/
-//define( 'EZP_USE_BUNDLED_COMPONENTS', true );
-
-
-/*
-   If you are not using the bundled eZ Components, then for optimal speed it is
-   recommended to set EZC_BASE_PATH to either ezc/Base/base.php or Base/src/base.php,
-   depending on how you installed the eZ Components. By default, if this setting
-   is not present, eZ Publish first tries to include ezc/Base/base.php in the standard
-   php include path. If that fails Base/src/base.php is included.
-*/
-//define( 'EZC_BASE_PATH', '/usr/lib/ezc/Base/base.php' );
-
 /*
    TIMEZONES
    ---------


### PR DESCRIPTION
This pull request is coming from upstream:
https://github.com/ezsystems/ezpublish-legacy/pull/1340

It is already merged. I looks like you requires you to setup the zeta components with composer. If you have the zeta components installed somewhere else and not in the 'vendor' subdirectory, I think it will break.
That could be the case for site upgrade we're planing to do.

I like that you can use composer to install the zeta components (it is a hassle to do with pear or direct download). On the other hand we're going to make the upgrade process a little more complicated. At least we would need to document this in our upgrade documentation.

Any thoughts?
