### PR TITLE
Submit not only node ids but also object ids to the ezpEvent "content/cache" event

### DIFF
--- a/kernel/classes/ezcontentcachemanager.php
+++ b/kernel/classes/ezcontentcachemanager.php
@@ -696,7 +696,7 @@ class eZContentCacheManager
 
         eZDebug::accumulatorStop( 'node_cleanup_list' );
 
-        return self::clearNodeViewCacheArray( $nodeList );
+        return self::clearNodeViewCacheArray( $nodeList, array( $objectID ) );
     }
 
     /**
@@ -728,16 +728,17 @@ class eZContentCacheManager
 
         eZDebug::accumulatorStop( 'node_cleanup_list' );
 
-        return self::clearNodeViewCacheArray( $nodeList );
+        return self::clearNodeViewCacheArray( $nodeList, $objectIDList );
     }
 
     /**
      * Clears view caches for an array of nodes.
      *
      * @param  array   $nodeList List of node IDs to clear
+     * @param  array|null   $contentObjectList List of content object IDs to clear
      * @return boolean returns true on success
      */
-    public static function clearNodeViewCacheArray( array $nodeList )
+    public static function clearNodeViewCacheArray( array $nodeList, array $contentObjectList = null )
     {
         if ( count( $nodeList ) == 0 )
         {
@@ -769,7 +770,7 @@ class eZContentCacheManager
 
         if ( eZContentCache::inCleanupThresholdRange( $cleanupValue ) )
         {
-            $nodeList = ezpEvent::getInstance()->filter( 'content/cache', $nodeList );
+            $nodeList = ezpEvent::getInstance()->filter( 'content/cache', $nodeList, $contentObjectList );
             eZContentCache::cleanup( $nodeList );
         }
         else

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -921,7 +921,7 @@ class eZContentOperationCollection
         }
 
         // Triggering content/cache filter for Http cache purge
-        ezpEvent::getInstance()->filter( 'content/cache', $removeNodeIdList );
+        ezpEvent::getInstance()->filter( 'content/cache', $removeNodeIdList, array_keys( $objectIdList ) );
         // we don't clear template block cache here since it's cleared in eZContentObjectTreeNode::removeNode()
 
         return array( 'status' => true );


### PR DESCRIPTION
Upstream pull request:
https://github.com/ezsystems/ezpublish-legacy/pull/1345

I has no effect for a pure legacy installation. Only if you use the legacy bridge and the new stack.

I don't like the code changes, still I decided to merge the changes:
- it is not affecting a pure legacy installation. It just just makes the code a little more complex.
- our lovestack should just work fine the the legacy bridge

What I don't like:
When clearing content cache, ezp gets a list of object IDs it needs to clear the cache for. It then resolves all corresponding node ids.
The legacy bridge is clearing the cache by object IDs. That's why the ezpEvent 'content/cache' is now sending both the list of node IDs and object IDs.
The legacy bridge is listen to this event, it then will translate all node IDs back to object ids and then clears the cache.
To me, that's sounds like a fairly in-efficient process.