### PR TITLE
Clearing all cache because of threshold now triggers a warning

### DIFF
--- a/kernel/classes/ezcontentcachemanager.php
+++ b/kernel/classes/ezcontentcachemanager.php
@@ -775,7 +775,7 @@ class eZContentCacheManager
         }
         else
         {
-            eZDebug::writeDebug( "Expiring all view cache since list of nodes({$cleanupValue}) exceeds site.ini\[ContentSettings]\CacheThreshold", __METHOD__ );
+            eZDebug::writeWarning( "Expiring all view cache since list of nodes({$cleanupValue}) exceeds site.ini\[ContentSettings]\CacheThreshold", __METHOD__ );
             ezpEvent::getInstance()->notify( 'content/cache/all' );
             eZContentObject::expireAllViewCache();
         }


### PR DESCRIPTION
Smallest pull request ever:
If clearing content cache and more than 200 nodes (by default setting) are about to get cleared, ezp will clear the entire content cache instead. That might be worth a debug message on small sites. But for bigger sites, that's at least worth a warning.
That's what this pull request does, changing the log message from debug to a warning message.
