### PR TITLE
Only try to set the session_name if the session has not started yet

### DIFF
--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -269,20 +269,23 @@ class eZSession
             return false;
 
         $ini = eZINI::instance();
-        if ( $sessionName !== false )
+        if ( $sessionName !== false && session_status() !== PHP_SESSION_ACTIVE )
         {
             session_name( $sessionName );
         }
         else if ( $ini->variable( 'Session', 'SessionNameHandler' ) === 'custom' )
         {
             $sessionName = $ini->variable( 'Session', 'SessionNamePrefix' );
-            if ( $ini->variable( 'Session', 'SessionNamePerSiteAccess' ) === 'enabled' )
+            if( $ini->variable( 'Session', 'SessionNamePerSiteAccess' ) === 'enabled' )
             {
-                $access = $GLOBALS['eZCurrentAccess'];
+                $access = $GLOBALS[ 'eZCurrentAccess' ];
                 // Use md5 to make sure name is only consistent of alphanumeric characters
-                $sessionName .=  md5( $access['name'] );
+                $sessionName .= md5( $access[ 'name' ] );
             }
-            session_name( $sessionName );
+            if( session_status() !== PHP_SESSION_ACTIVE )
+            {
+                session_name( $sessionName );
+            }
         }
         else
         {


### PR DESCRIPTION
Coming from upstream:
https://github.com/ezsystems/ezpublish-legacy/pull/1373

I decided to slightly change the approach and test if the session was started. Much more easier to read the code I think. The effect is pretty much the same.

This pull request is important in case you run PHP 7.2 in an ezp hybrid setup. Because PHP 7.2 generates a warning now and the new stack will error out with that warning.
