### PR TITLE
Always regenerate autoloads, package hosting URL changed

### DIFF
--- a/kernel/setup/steps/ezstep_create_sites.php
+++ b/kernel/setup/steps/ezstep_create_sites.php
@@ -72,13 +72,7 @@ class eZStepCreateSites extends eZStepInstaller
 
         $siteType = $this->chosenSiteType();
 
-        // If we are installing a package without extension packages we
-        // generate the autoload array for extensions.
-        // For the time being we only do this for the plain_site package.
-        if ( $siteType['identifier'] == 'plain_site' )
-        {
-            ezpAutoloader::updateExtensionAutoloadArray();
-        }
+        ezpAutoloader::updateExtensionAutoloadArray();
 
         $saveData = true; // set to true to save data
 

--- a/settings/package.ini
+++ b/settings/package.ini
@@ -12,10 +12,7 @@
 [RepositorySettings]
 RepositoryDirectory=packages
 # URL where eZ Publish setup wizard will fetch packages from
-# If you want to use the old packages which were available in
-# versions prior to 3.9 use the following URL instead:
-# http://packages.ez.no/ezpublish/3.9legacypackages
-RemotePackagesIndexURL=http://packages.ez.no/ezpublish/5.4/5.4.0
+RemotePackagesIndexURL=https://storage.googleapis.com/lovestack
 # If RemotePackagesIndexURL is empty, the RemotePackagesIndexURLBase setting
 # will be used, appended with the eZ Publish version numbers, like
 # RemotePackagesIndexURLBase/x.y/x.y.zalpha1


### PR DESCRIPTION
With this pull request we change the URL to lookup for available packages to install with the installation wizzard. The packages meta data and an example package has been created. So that the installation process fully works.
