### PR TITLE
Custom tag improvements

### DIFF
--- a/extension/ezoe/design/standard/javascript/plugins/custom_tags_controls/editor_plugin.js
+++ b/extension/ezoe/design/standard/javascript/plugins/custom_tags_controls/editor_plugin.js
@@ -1,0 +1,106 @@
+/**
+ * Custom Tags Controls TinyMCE plugin. When you focus a custom tag there will appear some extra controls
+ *
+ * @author Peter Keung
+ * @copyright Copyright 2014, Mugo Web
+ */
+
+( function()
+{
+    tinymce.create('tinymce.plugins.custom_tags_controls',
+    {
+        /**
+         * Initializes the plugin, this will be executed after the plugin has been created.
+         * This call is done before the editor instance has finished it's initialization so use the onInit event
+         * of the editor instance to intercept that event.
+         *
+         * @param {tinymce.Editor} ed Editor instance that the plugin is initialized in.
+         * @param {string} url Absolute URL to where the plugin is located.
+         */
+        init: function( ed, url )
+        {
+            var t = this;
+            ed.onKeyDown.add( function( ed, e )
+            {
+                if( e.keyCode != 8 )
+                {
+                    t.manageControls( ed );
+                }
+                else
+                {
+                    elem = jQuery( ed.selection.getNode() ).closest('div.ezoeItemCustomTag,div.ezoeItemContentTypeObjects');
+                    if( elem.length && elem.find('.custom_tags_controls').length != 0 && elem.text() == '' )
+                    {
+                        jQuery('<p><br></p>').insertBefore(elem);
+                        elem.remove();
+                    }
+                }
+            });
+            ed.onClick.add( function( ed, e )
+            {
+                
+                t.manageControls( ed );
+            });
+            ed.onRemove.add( function( ed, e )
+            {
+                t.manageControls( ed );
+            });
+        },
+        manageControls: function( ed )
+        {
+            elem = jQuery( ed.selection.getNode() ).closest('div.ezoeItemCustomTag,div.ezoeItemContentTypeObjects');
+            if( elem.length && elem.find('.custom_tags_controls').length == 0 )
+            {
+                // first remove all existing controls
+                this.removeControls( ed );
+                this.addControls( elem );
+            }
+            else if( elem.length == 0 )
+            {
+                this.removeControls( ed );
+            }
+        },
+        addControls: function( elem )
+        {
+            elem.append( '<span class="custom_tags_controls up"></span><span class="custom_tags_controls edit"></span><span class="custom_tags_controls down"></span>' );
+            elem.find('.custom_tags_controls.up').on('click', function(event){
+                event.preventDefault();
+                event.stopPropagation();
+                parent = jQuery(this).closest('div.ezoeItemCustomTag,div.ezoeItemContentTypeObjects');
+                if( parent.prev().length )
+                {
+                    parent.prev().insertAfter(parent);
+                }
+            });
+            elem.find('.custom_tags_controls.down').on('click', function(event){
+                event.preventDefault();
+                event.stopPropagation();
+                parent = jQuery(this).closest('div.ezoeItemCustomTag,div.ezoeItemContentTypeObjects');
+                if( parent.next().length )
+                {
+                    parent.next().insertBefore(parent);
+                    if( parent.next().length == 0 )
+                    {
+                        jQuery('<p><br></p>').insertAfter(parent);
+                    }
+                }
+            });
+            elem.find('.custom_tags_controls.edit').on('click', function(event){
+                event.preventDefault();
+                event.stopPropagation();
+                var ed = tinyMCE.activeEditor;
+                parent = jQuery(this).closest('div.ezoeItemCustomTag,div.ezoeItemContentTypeObjects');
+                var currentDomElement = jQuery( ed.selection.getNode() ).closest('div.ezoeItemCustomTag,div.ezoeItemContentTypeObjects').get(0);
+                var x = ed.theme.__getTagCommand( currentDomElement );
+                if (x) ed.execCommand( x.cmd, currentDomElement || false, x.val );
+            });
+        },
+        removeControls: function( ed )
+        {
+            jQuery( ed.selection.getNode() ).closest( 'body' ).find( '.custom_tags_controls' ).remove();
+        }
+    });
+
+    // Register plugin
+    tinymce.PluginManager.add( 'custom_tags_controls', tinymce.plugins.custom_tags_controls );
+})();

--- a/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
+++ b/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
@@ -1908,7 +1908,7 @@
 
         _mceCustom : function(ui, v)
         {
-            this._generalXmlTagPopup( false, 'custom/' + v, 0, 0, ui );
+            this._generalXmlTagPopup( false, 'custom/' + v, 950, 450, ui );
         },
 
         _mceLiteral : function(ui, v)

--- a/extension/ezoe/design/standard/stylesheets/mugo_editor.css
+++ b/extension/ezoe/design/standard/stylesheets/mugo_editor.css
@@ -1,0 +1,79 @@
+/* custom tags tag names in the blue box */
+div.ezoeItemCustomTag,
+div.ezoeItemContentTypeObjects
+{
+    position: relative;
+    padding: 1.5em !important;
+    min-height: 25px !important;
+}
+div.ezoeItemCustomTag p,
+div.ezoeItemContentTypeObjects p
+{
+    margin: 13px 0 13px 0 !important;
+}
+div.ezoeItemCustomTag:before
+{
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    background-color: #000;
+    color: #fff;
+    white-space: nowrap;
+    padding: 5px 20px;
+}
+
+div.ezoeItemCustomTag.factbox:before
+{
+    content: "factbox";
+}
+div.ezoeItemCustomTag.quote:before
+{
+    content: "quote";
+}
+div.ezoeItemCustomTag.strike:before
+{
+    content: "strike";
+}
+div.ezoeItemCustomTag.sub:before
+{
+    content: "sub";
+}
+div.ezoeItemCustomTag.sup:before
+{
+    content: "sup";
+}
+
+.custom_tags_controls
+{
+    position: absolute;
+    right: 5px;
+}
+
+.custom_tags_controls.up
+{
+    top: 5px;
+    width: 16px;
+    height: 16px;
+    background-image: url( "/extension/ezflow/design/admin/images/ezpage/block_up.gif" );
+    cursor: pointer; 
+}
+
+.custom_tags_controls.down
+{
+    bottom: 5px;
+    width: 16px;
+    height: 16px;
+    background-image: url( "/extension/ezflow/design/admin/images/ezpage/block_down.gif" );
+    cursor: pointer; 
+}
+
+.custom_tags_controls.edit
+{
+    bottom: 50%;
+    bottom: calc(50% - 8px);
+    width: 16px;
+    height: 16px;
+    background-image: url( "/design/standard/images/edit.gif" );
+    cursor: pointer; 
+}

--- a/extension/ezoe/design/standard/stylesheets/mugo_editor_dialog.css
+++ b/extension/ezoe/design/standard/stylesheets/mugo_editor_dialog.css
@@ -1,0 +1,72 @@
+.tag-type-custom table.custom_attributes tr[id$=_inline]
+{
+    display: none;
+}
+
+.tag-type-custom label,
+.tag-type-custom input,
+.tag-type-custom select,
+.tag-type-custom textarea
+{
+    font-size: 14px;
+}
+
+.tag-type-custom table.custom_attributes tr td
+{
+    vertical-align: top;
+}
+.tag-type-custom table.properties.general_attributes
+{
+    width: 45%;
+}
+.tag-type-custom table.custom_attributes tr td.left
+{
+    width: 50%;
+}
+
+
+.tag-type-custom table, .tag-type-custom table tr
+{
+    margin: 0;
+    padding: 0;
+}
+.tag-type-custom table.custom_attributes tr td.right
+{
+    position: relative;
+}
+.tag-type-custom table.custom_attributes tr td.right h2
+{
+    position: absolute;
+    top: -30px;
+    width: 100%;
+}
+
+.tag-type-custom table.custom_attributes tr td.left table,
+.tag-type-custom table.custom_attributes tr td.left textarea,
+.tag-type-custom table.custom_attributes tr td.left select,
+.tag-type-custom table.custom_attributes tr td.left input:not([type=checkbox]),
+.tag-type-custom table.properties.general_attributes select
+{
+    width: 90%;
+}
+.tag-type-custom table.custom_attributes tr td.left select.atr_link_source_types
+{
+    width: 66%;
+}
+
+.tag-type-custom table.custom_attributes tr td.left table td:first-child,
+.tag-type-custom table.properties.general_attributes .column1
+{
+    width: 40%;
+}
+
+.tag-type-custom table.custom_attributes tr td.right
+{
+    text-align: center;
+}
+
+.tag-type-custom table.custom_attributes tr td.right img
+{
+    max-width: 100%;
+}
+

--- a/extension/ezoe/design/standard/templates/ezoe/customattributes.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/customattributes.tpl
@@ -38,85 +38,99 @@
     {/if}
 
     <table class="properties custom_attributes" id="{$:tag_name}_customattributes"{if $:hide} style="display: none;"{/if}>
-    {foreach $custom_attributes as $custom_attribute}
-        {if $shown_attributes|contains( $custom_attribute )}{continue}{/if}
+        <tr>
+            <td class="left">
+                <table>
+                    {foreach $custom_attributes as $custom_attribute}
+                        {if $shown_attributes|contains( $custom_attribute )}{continue}{/if}
 
-        {set $shown_attributes           = $shown_attributes|append( $custom_attribute )}
-        {set $custom_attribute_id        = concat( $:tag_name, '_', $custom_attribute)|wash}
-        {set $custom_attribute_classes    = array()}
+                        {set $shown_attributes           = $shown_attributes|append( $custom_attribute )}
+                        {set $custom_attribute_id        = concat( $:tag_name, '_', $custom_attribute)|wash}
+                        {set $custom_attribute_classes    = array()}
 
-        {if ezoe_ini_section( concat('CustomAttribute_', $:tag_name, '_', $custom_attribute), 'ezoe_attributes.ini' )}
-            {set $custom_attribute_settings = concat('CustomAttribute_', $:tag_name, '_', $custom_attribute)}
-        {else}
-            {set $custom_attribute_settings = concat('CustomAttribute_', $custom_attribute)}
-        {/if}
+                        {if ezoe_ini_section( concat('CustomAttribute_', $:tag_name, '_', $custom_attribute), 'ezoe_attributes.ini' )}
+                            {set $custom_attribute_settings = concat('CustomAttribute_', $:tag_name, '_', $custom_attribute)}
+                        {else}
+                            {set $custom_attribute_settings = concat('CustomAttribute_', $custom_attribute)}
+                        {/if}
 
-        {if ezini_hasvariable( $custom_attribute_settings, 'Disabled', 'ezoe_attributes.ini' )}
-            {set $custom_attribute_disabled = ezini( $custom_attribute_settings, 'Disabled', 'ezoe_attributes.ini' )|eq('true')}
-        {else}
-            {set $custom_attribute_disabled = false()}
-        {/if}
+                        {if ezini_hasvariable( $custom_attribute_settings, 'Disabled', 'ezoe_attributes.ini' )}
+                            {set $custom_attribute_disabled = ezini( $custom_attribute_settings, 'Disabled', 'ezoe_attributes.ini' )|eq('true')}
+                        {else}
+                            {set $custom_attribute_disabled = false()}
+                        {/if}
 
-        {if ezini_hasvariable( $custom_attribute_settings, 'Type', 'ezoe_attributes.ini' )}
-            {set $custom_attribute_type = ezini( $custom_attribute_settings, 'Type', 'ezoe_attributes.ini' )}
-        {else}
-            {set $custom_attribute_type = 'text'}
-        {/if}
+                        {if ezini_hasvariable( $custom_attribute_settings, 'Type', 'ezoe_attributes.ini' )}
+                            {set $custom_attribute_type = ezini( $custom_attribute_settings, 'Type', 'ezoe_attributes.ini' )}
+                        {else}
+                            {set $custom_attribute_type = 'text'}
+                        {/if}
+
+                        {if ezini_hasvariable( $custom_attribute_settings, 'Default', 'ezoe_attributes.ini' )}
+                            {set $custom_attribute_default = ezini( $custom_attribute_settings, 'Default', 'ezoe_attributes.ini' )}
+                        {else}
+                            {set $custom_attribute_default = first_set( $custom_attributes_defaults[$custom_attribute], '' )}
+                        {/if}
+
+                        {if ezini_hasvariable( $custom_attribute_settings, 'Name', 'ezoe_attributes.ini' )}
+                            {set $custom_attribute_name = ezini( $custom_attribute_settings, 'Name', 'ezoe_attributes.ini' )}
+                        {elseif is_set( $i18n[ $custom_attribute ] )}
+                            {set $custom_attribute_name = $i18n[ $custom_attribute ]}
+                        {else}
+                            {set $custom_attribute_name = $custom_attribute|upfirst}
+                        {/if}
+
+                        {if ezini_hasvariable( $custom_attribute_settings, 'Title', 'ezoe_attributes.ini' )}
+                            {set $custom_attribute_title = ezini( $custom_attribute_settings, 'Title', 'ezoe_attributes.ini' )}
+                        {else}
+                            {set $custom_attribute_title = first_set( $attribute_titles[$xml_attribute], '' )}
+                        {/if}
+
+                                {if ezini_hasvariable( $custom_attribute_settings, 'Required', 'ezoe_attributes.ini' )}
+                                    {if ezini( $custom_attribute_settings, 'Required', 'ezoe_attributes.ini' )|eq('true')}
+                                        {set $custom_attribute_classes = $custom_attribute_classes|append( 'required' )}
+                                    {/if}
+                                {/if}
+
+                        {if ezini_hasvariable( $custom_attribute_settings, 'AllowEmpty', 'ezoe_attributes.ini' )}
+                            {if ezini( $custom_attribute_settings, 'AllowEmpty', 'ezoe_attributes.ini' )|eq('true')}
+                                {set $custom_attribute_classes = $custom_attribute_classes|append( 'allow_empty' )}
+                            {/if}
+                        {/if}
+
+                        <tr id="{$custom_attribute_id}" class="custom_attribute_type_{$custom_attribute_type}">
+                            {if $custom_attribute_type|ne('hidden')}
+                            <td class="column1"><label for="{$custom_attribute_id}_source">
+                                {$custom_attribute_name|wash}
+                            </label></td>
+                            <td>
+                            {else}
+                            <td colspan="2">
+                            {/if}
+                                {include uri=concat('design:ezoe/customattributes/', $custom_attribute_type, '.tpl')}
+                            </td>
+                        </tr>
+                    {/foreach}
+                    {if $extra_attribute}
+                        {set $custom_attribute_id  = concat( $:tag_name, '_', $extra_attribute.0)|wash}
+                        <tr id="{$custom_attribute_id}">
+                            <td class="column1">
+                                <label for="{$custom_attribute_id}_source">{$extra_attribute.0|upfirst|wash}</label>
+                            </td>
+                            <td><input type="checkbox" class="input_noborder mceItemSkip" name="{$extra_attribute.0}" id="{$custom_attribute_id}_source" value="{$extra_attribute.1|wash}"{if $extra_attribute.2} checked="checked"{/if} disabled="disabled" /></td>
+                        </tr>
+                    {/if}
+                </table>
+            </td>
+            <td class="right">
+                {* ez won't have the images in place in the default design folder, so we check if ezimage don't return this path *}
+                {if concat( 'editor/custom_tags_thumbs/', $:tag_name, '.png' )|ezimage(no)|begins_with( '/design' )|not}
+                    <h2>Example:</h2>
+                    <img src="{concat( 'editor/custom_tags_thumbs/', $:tag_name, '.png' )|ezimage(no)}">
+                {/if}
+            </td>
+        </tr>
         
-        {if ezini_hasvariable( $custom_attribute_settings, 'Default', 'ezoe_attributes.ini' )}
-            {set $custom_attribute_default = ezini( $custom_attribute_settings, 'Default', 'ezoe_attributes.ini' )}
-        {else}
-            {set $custom_attribute_default = first_set( $custom_attributes_defaults[$custom_attribute], '' )}
-        {/if}
-
-        {if ezini_hasvariable( $custom_attribute_settings, 'Name', 'ezoe_attributes.ini' )}
-            {set $custom_attribute_name = ezini( $custom_attribute_settings, 'Name', 'ezoe_attributes.ini' )}
-        {elseif is_set( $i18n[ $custom_attribute ] )}
-            {set $custom_attribute_name = $i18n[ $custom_attribute ]}
-        {else}
-            {set $custom_attribute_name = $custom_attribute|upfirst}
-        {/if}
-
-        {if ezini_hasvariable( $custom_attribute_settings, 'Title', 'ezoe_attributes.ini' )}
-            {set $custom_attribute_title = ezini( $custom_attribute_settings, 'Title', 'ezoe_attributes.ini' )}
-        {else}
-            {set $custom_attribute_title = first_set( $attribute_titles[$xml_attribute], '' )}
-        {/if}
-
-		{if ezini_hasvariable( $custom_attribute_settings, 'Required', 'ezoe_attributes.ini' )}
-		    {if ezini( $custom_attribute_settings, 'Required', 'ezoe_attributes.ini' )|eq('true')}
-		        {set $custom_attribute_classes = $custom_attribute_classes|append( 'required' )}
-		    {/if}
-		{/if}
-
-        {if ezini_hasvariable( $custom_attribute_settings, 'AllowEmpty', 'ezoe_attributes.ini' )}
-            {if ezini( $custom_attribute_settings, 'AllowEmpty', 'ezoe_attributes.ini' )|eq('true')}
-                {set $custom_attribute_classes = $custom_attribute_classes|append( 'allow_empty' )}
-            {/if}
-        {/if}
-
-        <tr id="{$custom_attribute_id}" class="custom_attribute_type_{$custom_attribute_type}">
-            {if $custom_attribute_type|ne('hidden')}
-            <td class="column1"><label for="{$custom_attribute_id}_source">
-                {$custom_attribute_name|wash}
-            </label></td>
-            <td>
-            {else}
-            <td colspan="2">
-            {/if}
-                {include uri=concat('design:ezoe/customattributes/', $custom_attribute_type, '.tpl')}
-            </td>
-        </tr>
-    {/foreach}
-    {if $extra_attribute}
-        {set $custom_attribute_id  = concat( $:tag_name, '_', $extra_attribute.0)|wash}
-        <tr id="{$custom_attribute_id}">
-            <td class="column1">
-                <label for="{$custom_attribute_id}_source">{$extra_attribute.0|upfirst|wash}</label>
-            </td>
-            <td><input type="checkbox" class="input_noborder mceItemSkip" name="{$extra_attribute.0}" id="{$custom_attribute_id}_source" value="{$extra_attribute.1|wash}"{if $extra_attribute.2} checked="checked"{/if} disabled="disabled" /></td>
-        </tr>
-    {/if}
     </table>
 {/if}
 {/default}

--- a/extension/ezoe/design/standard/templates/ezoe/customattributes/select.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/customattributes/select.tpl
@@ -1,8 +1,41 @@
+{* Override to support suppression of custom tags *}
 <select name="{$custom_attribute}" id="{$custom_attribute_id}_source"{if $custom_attribute_disabled} disabled="disabled"{/if} title="{$custom_attribute_title|wash}" class="{$custom_attribute_classes|implode(' ')}">
 {if ezini_hasvariable( $custom_attribute_settings, 'Selection', 'ezoe_attributes.ini' )}
 {foreach ezini( $custom_attribute_settings, 'Selection', 'ezoe_attributes.ini' ) as $custom_value => $custom_name}
     <option value="{if $custom_value|ne('-0-')}{$custom_value|wash}{/if}"{if $custom_value|eq( $custom_attribute_default )} selected="selected"{/if}>{$custom_name|wash}</option>
 {/foreach}
+{elseif and( is_set($custom_attribute_selection), is_array($custom_attribute_selection), $custom_attribute_id|eq('custom_name') )}
+    {def $tag_groups=hash()
+         $tags_in_group=array()
+         $main_tags=array()
+         $custom_name=''}
+
+    {if is_unset( $suppress_custom_tags )}
+        {def $suppress_custom_tags = ezini( 'CustomTagSettings', 'SuppressedCustomTags', 'content.ini' )}
+    {/if}
+
+    {foreach ezini( 'CustomTagSettings', 'CustomTagGroups', 'content.ini' ) as $tag_group_id => $tag_group_name}
+        {set $tag_groups=$tag_groups|merge( hash($tag_group_name,  ezini( 'CustomTagSettings', concat( 'CustomTagGroups_', $tag_group_id ), 'content.ini' ) ) )
+             $tags_in_group=$tags_in_group|merge(ezini( 'CustomTagSettings', concat( 'CustomTagGroups_', $tag_group_id ), 'content.ini' ))}
+    {/foreach}
+
+    {foreach $custom_attribute_selection as $custom_value => $custom_name}
+        {if not( $tags_in_group|contains( $custom_value ) )}
+            {set $main_tags=$main_tags|append( $custom_value )}
+        {/if}
+    {/foreach}
+
+    {foreach hash( 'Main', $main_tags )|merge( $tag_groups ) as $group_name => $group_tags}
+        <optgroup label="{$group_name|wash}">
+        {foreach $group_tags as $custom_value}
+            {set $custom_name=$custom_attribute_selection[$custom_value]}
+            {if and( $custom_attribute_id|eq( 'custom_name' ), $suppress_custom_tags|contains( $custom_value ) )}
+                {continue}
+            {/if}
+            <option value="{if $custom_value|ne('-0-')}{$custom_value|wash}{/if}"{if $custom_value|eq( $custom_attribute_default )} selected="selected"{/if}>{$custom_name|wash}</option>
+        {/foreach}
+        </optgroup>
+    {/foreach}
 {elseif and( is_set($custom_attribute_selection), is_array($custom_attribute_selection) )}
 {foreach $custom_attribute_selection as $custom_value => $custom_name}
     <option value="{if $custom_value|ne('-0-')}{$custom_value|wash}{/if}"{if $custom_value|eq( $custom_attribute_default )} selected="selected"{/if}>{$custom_name|wash}</option>

--- a/extension/ezoe/settings/content.ini.append.php
+++ b/extension/ezoe/settings/content.ini.append.php
@@ -1,6 +1,16 @@
 <?php /* #?ini charset="utf-8"?
 # eZ publish configuration file for content and ez xml tags
 #
+# ATTENTION!
+# When adding new tags it is necessary to update:
+# extension/yourextension/design/admin/stylesheets/custom_editor.css
+# Example:
+# div.ezoeItemCustomTag.factbox:before
+# {
+#    content: "factbox";
+# }
+# so it displays the custom tag label in the online editor
+# also image previews should be placed at extension/yourextension/design/admin/images/editor/custom_tags_thumbs/
 
 # Some custom tags add special features to the editor if enabled:
 # underline: adds underline button in edtor (use this instead of custom tag to make the text appear underlined)

--- a/extension/ezoe/settings/design.ini.append.php
+++ b/extension/ezoe/settings/design.ini.append.php
@@ -12,6 +12,8 @@ DesignExtensions[]=ezoe
 # this [optional]variable is taken from ezoe.ini
 EditorCSSFileList[]=skins/<skin>/content.css
 
+EditorDialogCSSFileList[]=mugo_editor_dialog.css
+EditorCSSFileList[]=mugo_editor.css
 
 ## Here is an example for appending your own css to the editor
 ## content you need to place it in the stylesheets folder in

--- a/extension/ezoe/settings/ezoe.ini
+++ b/extension/ezoe/settings/ezoe.ini
@@ -8,6 +8,7 @@
 # plugins not mentioned here aren't tested and therefore not supported together with Online Editor
 Plugins[]
 Plugins[]=eztable
+Plugins[]=custom_tags_controls
 #Plugins[]=insertdatetime
 #Plugins[]=visualchars
 # Support for button to insert nonbreaking white space


### PR DESCRIPTION
Group tags into "optgroups"
Make the custom tag modal bigger
Support arrow re-ordering of custom tags
Show the name of the custom tag
Trigger edit modal within the editor

You can test everything by editing any content object with an ezxml attribute.