### PR TITLE
Fetch function parameter "class_filter_type" with smart default value

### DIFF
--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -374,6 +374,12 @@ class eZContentFunctionCollection
 
         if ( is_numeric( $parentNodeID ) or is_array( $parentNodeID ) )
         {
+            // Set an unset ClassFilterType to 'include' if 'ClassFilterArray' is set
+            if( !empty( $class_filter_array ) && !$class_filter_type )
+            {
+                $class_filter_type = 'include';
+            }
+
             $childrenCount = eZContentObjectTreeNode::subTreeCountByNodeID( array( 'Limitation' => $limitation,
                                                                            'ClassFilterType' => $class_filter_type,
                                                                            'ClassFilterArray' => $class_filter_array,

--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -342,6 +342,12 @@ class eZContentFunctionCollection
             $treeParameters['DepthOperator'] = $depthOperator;
         }
 
+        // Set an unset ClassFilterType to 'include' if 'ClassFilterArray' is set
+        if( !empty( $treeParameters[ 'ClassFilterArray' ] ) && !$treeParameters[ 'ClassFilterType' ] )
+        {
+            $treeParameters[ 'ClassFilterType' ] = 'include';
+        }
+
         $children = null;
         if ( is_numeric( $parentNodeID ) or is_array( $parentNodeID ) )
         {


### PR DESCRIPTION
This pull request will allow template developers to write fetch functions like 'content/tree' or 'content/list' and specify a `class_filter_array` parameter without a `class_filter_type` parameter. In that case the fetch function assumes that the `class_filter_type` value is `include`.

In almost all cases you want the `class_filter_type` parameter to be set to `include`. So it makes sense to have it set to `include` by default. Only in very few cases you want to have it set to `exclude`. In that case you have to explicitly set the parameter (which was the case before this pull request anyways).

In all other cases, you can omit the parameter in the fetch function and template developers can write fetch functions more quickly, easier to read.

**Testing instructions**
In the pagelayout template add a fetch function like this one:

```
	{def $result = fetch( 'content', 'tree', hash(
		'parent_node_id', 2,
		'class_filter_type', 'include',
		'class_filter_array', array( 'folder' )
	) ) }

	{$result|dump()}
```
I assume you have a 'folder' node under the root node (node_id 2). Run this example and confirm the expected output. Then you need to try a few variations:
* with and without the `class_filter_type` parameter
* with 'folder' and 'image' for the `class_filter_array` parameter value (assume images are not present under the root node)
* with 'exclude' for the `class_filter_type` parameter value
* with the fetch functions 'tree_count' and 'list_count'
