### PR TITLE
Bug fix: email address with special chars do not fail anymore

### DIFF
--- a/design/admin/templates/shop/orderlist.tpl
+++ b/design/admin/templates/shop/orderlist.tpl
@@ -73,7 +73,7 @@
     {if is_null($Orders.item.account_name)}
         <s><i>{'( removed )'|i18n( 'design/admin/shop/orderlist' )}</i></s>
     {else}
-        <a href={concat( '/shop/customerorderview/', $Orders.item.user_id, '/', $Orders.item.account_email )|ezurl}>{$Orders.item.account_name|wash}</a>
+        <a href={concat( '/shop/customerorderview/', $Orders.item.user_id, '/', $Orders.item.account_email|urlencode() )|ezurl}>{$Orders.item.account_name|wash}</a>
     {/if}
     </td>
     

--- a/design/standard/templates/shop/orderlist.tpl
+++ b/design/standard/templates/shop/orderlist.tpl
@@ -49,7 +49,7 @@
 	{$Order:item.created|l10n(shortdatetime)}
 	</td>
 	<td class="{$Order:sequence}">
-    <a href={concat("/shop/customerorderview/",$Order:item.user_id,"/",$Order:item.account_email)|ezurl}>{$Order:item.account_name|wash}</a>
+    <a href={concat("/shop/customerorderview/",$Order:item.user_id,"/",$Order:item.account_email|urlencode() )|ezurl}>{$Order:item.account_name|wash}</a>
 	</td>
 	<td class="{$Order:sequence}">
 	{$Order:item.total_ex_vat|l10n(currency)}

--- a/kernel/shop/customerorderview.php
+++ b/kernel/shop/customerorderview.php
@@ -15,7 +15,6 @@ $http = eZHTTPTool::instance();
 
 $tpl = eZTemplate::factory();
 
-$Email = urldecode( $Email );
 $productList = eZOrder::productList( $CustomerID, $Email );
 $orderList = eZOrder::orderList( $CustomerID, $Email );
 


### PR DESCRIPTION
There is a bug in the shop system this pull request fixes. You can reproduce the issue like this:

- Go to the admin UI
- Create a Product object
- View the new Product node, click 'Add to basket'
- Click 'Checkout'
- In the following form enter an email address with the '+' char. For example myname+test@gmail.com.
- Then try to view that new order
- http://yourdomain/shop/orderlist 
- Click on the customer name
Now:
Without this patch the screen is almost empty and does not show any order details.
With this patch you will see all order details.

