### PR TITLE
Remove default declaration of ezenum

### DIFF
--- a/settings/content.ini
+++ b/settings/content.ini
@@ -80,7 +80,6 @@ AvailableDataTypes[]=eztime
 AvailableDataTypes[]=ezboolean
 AvailableDataTypes[]=ezinteger
 AvailableDataTypes[]=ezfloat
-AvailableDataTypes[]=ezenum
 AvailableDataTypes[]=ezobjectrelation
 AvailableDataTypes[]=ezobjectrelationlist
 AvailableDataTypes[]=ezimage


### PR DESCRIPTION
The ezenum datatype has been moved to the legacy_2018 extension. But there is still a lingering datatype declaration that results in this error:

`Datatype not found: 'ezenum', searched in these directories: kernel/classes/datatypes`