### PR TITLE
Cache clearing for ezjscore files fixed

### DIFF
--- a/extension/ezjscore/classes/ezjsccachemanager.php
+++ b/extension/ezjscore/classes/ezjsccachemanager.php
@@ -9,15 +9,70 @@
 
 class ezjscCacheManager
 {
+    static protected $purge = false;
+
     /**
-     * Recursively expires the ezjscore public cache folder
+     * Expires the ezjscore public cache folder's JS/CSS files by deleting all files that are more than n days old
+     * The expiry date for JS/CSS files is defined in [Cache_ezjscore]maxage in site.ini
      * @param array $cacheItem
      */
     public static function clearCache( array $cacheItem )
     {
-        eZClusterFileHandler::instance()->fileDeleteByDirList(
-            array( 'javascript', 'stylesheets' ),
-            eZSys::cacheDirectory() . '/' . $cacheItem['path'], ''
-        );
+        $clusterHandler = eZClusterFileHandler::instance();
+
+        // Get the existing JavaScript and stylesheet files
+        $existingFiles = $clusterHandler->getFileList( [ 'ezjscore' ] );
+
+        // Loop through all the existing files
+        foreach( $existingFiles as $file )
+        {
+            $clusterHandler->filePath = $file;
+            $clusterHandler->loadMetaData();
+            $metaData = $clusterHandler->metaData;
+            
+            // If the timestamp is before than $maxAge
+            if( $metaData[ 'mtime' ] < self::getMaxAge() )
+            {
+                if( self::$purge )
+                {
+                    eZClusterFileHandler::instance()->filePurge( $file );
+                }
+                else
+                {
+                    eZClusterFileHandler::instance()->fileDelete( $file );
+                }
+            }
+        }
+    }
+
+    /**
+     * Run when --purge is applied, but we do the same as without --purge
+     *
+     * @param array $cacheItem
+     */
+    public static function purgeCache( array $cacheItem )
+    {
+        self::$purge = true;
+        self::clearCache( $cacheItem );
+    }
+
+    private static function getMaxAge()
+    {
+        $ini = eZINI::instance();
+        if( $ini->hasVariable( "Cache_ezjscore", "Maxage" ) )
+        {
+            if( $ini->variable( "Cache_ezjscore", "Maxage" ) )
+            {
+                return strtotime( "-" . $ini->variable( "Cache_ezjscore", "Maxage" ) );
+            }
+            else
+            {
+                return time();
+            }
+        }
+        else
+        {
+            return strtotime( "-90 days" );
+        }
     }
 }

--- a/extension/ezjscore/classes/ezjsccachemanager.php
+++ b/extension/ezjscore/classes/ezjsccachemanager.php
@@ -29,7 +29,7 @@ class ezjscCacheManager
             $clusterHandler->filePath = $file;
             $clusterHandler->loadMetaData();
             $metaData = $clusterHandler->metaData;
-            
+
             // If the timestamp is before than $maxAge
             if( $metaData[ 'mtime' ] < self::getMaxAge() )
             {
@@ -59,11 +59,15 @@ class ezjscCacheManager
     private static function getMaxAge()
     {
         $ini = eZINI::instance();
-        if( $ini->hasVariable( "Cache_ezjscore", "Maxage" ) )
+        if( $ini->hasVariable( 'Cache_ezjscore', 'Maxage' ) )
         {
-            if( $ini->variable( "Cache_ezjscore", "Maxage" ) )
+            if( $ini->variable( 'Cache_ezjscore', 'Maxage' ) )
             {
-                return strtotime( "-" . $ini->variable( "Cache_ezjscore", "Maxage" ) );
+                return strtotime(
+                    '-' .
+                    (int) $ini->variable( 'Cache_ezjscore', 'Maxage' ) .
+                    ' days'
+                );
             }
             else
             {
@@ -72,7 +76,7 @@ class ezjscCacheManager
         }
         else
         {
-            return strtotime( "-90 days" );
+            return strtotime( '-90 days' );
         }
     }
 }

--- a/extension/ezjscore/settings/site.ini.append.php
+++ b/extension/ezjscore/settings/site.ini.append.php
@@ -30,6 +30,8 @@ tags[]=content
 tags[]=template
 path=public
 isClustered=true
+#Do not delete/purge files younger than X days
+Maxage=0
 class=ezjscCacheManager
 
 

--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -696,6 +696,11 @@ class eZFSFileHandler implements eZClusterFileHandlerInterface
         eZDebug::accumulatorStop( 'dbfile' );
     }
 
+    public function filePurge( $path )
+    {
+        $this->fileDelete( $path );
+    }
+
     /**
      * Deletes specified file/directory.
      *
@@ -998,7 +1003,32 @@ class eZFSFileHandler implements eZClusterFileHandlerInterface
 
     public function getFileList($scopes = false, $excludeScopes = false)
     {
-        return false;
+        $return = [];
+
+        if( !empty( $scopes ) )
+        {
+            foreach( $scopes as $scope )
+            {
+                switch( $scope )
+                {
+                    case 'ezjscore':
+                    {
+                        $varDir = eZINI::instance()->variable( 'FileSettings', 'VarDir' );
+
+                        $return = array_merge(
+                            $return,
+                            eZDir::recursiveFind( $varDir .'/cache/public/javascript/', '.' )
+                        );
+                        $return = array_merge(
+                            $return,
+                            eZDir::recursiveFind( $varDir .'/cache/public/stylesheets/', '.' )
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+        return $return;
     }
 
     public function isDBFileExpired($expiry, $curtime, $ttl)

--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -1024,6 +1024,28 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
     }
 
     /**
+     * @param string $path
+     * @return bool|eZMySQLBackendError
+     */
+    public function filePurge( $path )
+    {
+        $path = self::cleanPath( $path );
+        $return = self::$dbbackend->_purge( $path );
+
+        // Remove local copies
+        if ( is_file( $path ) )
+        {
+            @unlink( $path );
+        }
+        elseif ( is_dir( $path ) )
+        {
+            eZDir::recursiveDelete( $path );
+        }
+
+        return $return;
+    }
+
+    /**
      * Deletes specified file/directory.
      *
      * If a directory specified it is deleted recursively.


### PR DESCRIPTION
**Testing instructions**
1) edit settings/override/site.ini.append.php
2) comment out this line `#DevelopmentMode=enabled` - so that it is disabled
3) Clear cache
4) confirm you get combined/minimized JS and CSS requests when accessing the backend or frontend
5) Get the path to such a file - for example:
var/ezdemo_site/cache/public/javascript/c614d2f9a78df37204b56131597c3832.js
6) Confirm the file exists:
   cd ezp_root
   ls var/ezdemo_site/cache/public/javascript/c614d2f9a78df37204b56131597c3832.js

7) Clear cache: php bin/php/ezcache.php --clear-all
8) Confirm the file is gone
9) Edit extension/ezjscore/settings/site.ini.append.php
10) Set Maxage=0 to Maxage=10
11) Now repeat the test from point 3) on - this time the js/css file should still exists on the filesystem after clearing the cache

