### PR TITLE
#607 - Bug fix: INI settings don't support loose typing

### DIFF
--- a/settings/contentstructuremenu.ini
+++ b/settings/contentstructuremenu.ini
@@ -36,8 +36,7 @@ MaxNodes=150
 #    SortBy[]
 #    SortBy[]=name/ascending
 #    SortBy[]=published/descending
-# if set to "false" - default sorting will be implemented
-# (which is defined for each node)
+# if not set - it usese the sorting defined for each node (Ordering)
 SortBy[]
 
 # enabled/disabled

--- a/settings/contentstructuremenu.ini
+++ b/settings/contentstructuremenu.ini
@@ -38,7 +38,7 @@ MaxNodes=150
 #    SortBy[]=published/descending
 # if set to "false" - default sorting will be implemented
 # (which is defined for each node)
-SortBy=false
+SortBy[]
 
 # enabled/disabled
 ToolTips=enabled


### PR DESCRIPTION
Sort is a useful setting to sort menu alphabetically in the Administration Interface.

But if you use that setting with an array and try to view the contentstructuremenu.ini settings in Setup > Ini settings, you will get this error:

```
An unexpected error has occurred. Please contact the webmaster.
[] operator not supported for strings in /var/www/marigold/ezpublish_legacy/lib/ezutils/classes/ezini.php on line 868
```

To prevent this bug, update the Sort setting on contentstructuremenu.ini as we can see in this commit.