### PR TITLE
Default "Cache-Control" header to "public" for front-end siteaccesses so that Varnish / reverse proxies can cache

### DIFF
--- a/settings/siteaccess/base/site.ini.append
+++ b/settings/siteaccess/base/site.ini.append
@@ -7,3 +7,10 @@ RequireUserLogin=false
 [DesignSettings]
 StandardDesign=standard
 SiteDesign=base
+
+[HTTPHeaderSettings]
+# Legacy responses are getting Cache-Control:private by default.
+# Force them to be public so Varnish / reverse proxies can cache
+CustomHeader=enabled
+OnlyForContent=disabled
+Cache-Control[/]=public

--- a/settings/siteaccess/mysite/site.ini.append
+++ b/settings/siteaccess/mysite/site.ini.append
@@ -23,3 +23,10 @@ SiteDesign=mysite
 # if the design was not found in the main 
 # sitedesign. StandardDesign is the fallback design.
 AdditionalSiteDesignList[]=
+
+[HTTPHeaderSettings]
+# Legacy responses are getting Cache-Control:private by default.
+# Force them to be public so Varnish / reverse proxies can cache
+CustomHeader=enabled
+OnlyForContent=disabled
+Cache-Control[/]=public

--- a/settings/siteaccess/plain/site.ini.append
+++ b/settings/siteaccess/plain/site.ini.append
@@ -15,3 +15,10 @@ RequireUserLogin=false
 
 [DesignSettings]
 SiteDesign=plain
+
+[HTTPHeaderSettings]
+# Legacy responses are getting Cache-Control:private by default.
+# Force them to be public so Varnish / reverse proxies can cache
+CustomHeader=enabled
+OnlyForContent=disabled
+Cache-Control[/]=public


### PR DESCRIPTION
@peterkeung re-discovered and fixed the issue on a recent migration/upgrade.

In an eZ Platform + LegacyBridge + Lovestack setup Varnish was unable to cache the legacy responses due to the cache control header being sent as 'private'.

The updated setting fixes the issue so that when used in frontend siteaccesses Varnish can cache what needs to be cached.

The questions remaining:

    enable this by default?
    does it need further explanation?
