### PR TITLE
Removes the session cookie after login

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1111,9 +1111,8 @@ WHERE user_id = '" . $userID . "' AND
             self::cleanup();
         }
 
-        // give user new session id
-        eZSession::regenerate();
-
+        // drop session
+        eZSession::remove();
         // set the property used to prevent SSO from running again
         self::$userHasLoggedOut = true;
     }

--- a/lib/ezsession/classes/ezpsessionhandlerphp.php
+++ b/lib/ezsession/classes/ezpsessionhandlerphp.php
@@ -53,6 +53,7 @@ class ezpSessionHandlerPHP extends ezpSessionHandler
     {
         $_SESSION = array();
         session_destroy();
+        setcookie( session_name(), "", time()-3600, '/' );
 
         ezpEvent::getInstance()->notify( 'session/destroy', array( $sessionId ) );
         return true;


### PR DESCRIPTION
On logout the system should remove the session cookie but that was not the case.

On logout, it was just generating a new session ID - that new session ID is not logged in anymore.

That's a problem if you like to setup Varnish (Reverse Proxy) caching rules that are using the session cookie for the cache variations. 

**Testing Instructions**
* Login to http://dev.lovestack.mugo.ca/user/login
* In your browser (Chrome):
* open the console
* choose the 'Application' tab
* on the left side menu, choose the cookies of your admin UI domain
* Confirm you see a session cookie with the name starting with 'eZSESSIONID....'
* Logout: http://dev.lovestack.mugo.ca/user/logout
* Confirm the session cookie 'eZSESSIONID' is gone

