### PR TITLE
lastVisit returns _false_ in case the user never logged in before

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1544,7 +1544,7 @@ WHERE user_id = '" . $userID . "' AND
         }
         else
         {
-            return time();
+            return false;
         }
     }
 


### PR DESCRIPTION
The code used to return the current timestamp value _time()_ for users that never logged in. That does not make a lot of sense.