### PR TITLE
Allow to configure the tpl edit URL in the Used Templates list

### DIFF
--- a/kernel/common/eztemplatesstatisticsreporter.php
+++ b/kernel/common/eztemplatesstatisticsreporter.php
@@ -26,6 +26,9 @@ class eZTemplatesStatisticsReporter
         if ( !eZTemplate::isTemplatesUsageStatisticsEnabled() )
             return $stats;
 
+        $settings = eZINI::instance();
+        $templateEditUrl = $settings->variable( 'DebugSettings', 'UsedTemplateEditUrl' );
+
         if ( $as_html )
         {
             $stats .= "<h3>Templates used to render the page:</h3>";
@@ -111,7 +114,7 @@ class eZTemplatesStatisticsReporter
                            "<td><a href=\"$requestedTemplateViewURI\">$requestedTemplateName</a></td>" .
                            "<td>$actualTemplateNameOutput</td>" .
                            "<td>$templateFileName</td>" .
-                           "<td><a href=\"$templateEditURI/(siteAccess)/$currentSiteAccess\"><img src=\"$editIconFile\" width=\"$iconSizeX\" height=\"$iconSizeY\" alt=\"Edit template\" title=\"Edit template\" /></a></td>".
+                           "<td><a href=\"". sprintf( $templateEditUrl, $templateEditURI, $currentSiteAccess, $templateFileName ) ."\"><img src=\"$editIconFile\" width=\"$iconSizeX\" height=\"$iconSizeY\" alt=\"Edit template\" title=\"Edit template\" /></a></td>".
                            "<td><a href=\"$templateOverrideURI/(siteAccess)/$currentSiteAccess\"><img src=\"$overrideIconFile\" width=\"$iconSizeX\" height=\"$iconSizeY\" alt=\"Override template\" title=\"Override template\" /></a></td></tr>" );
 
                     $j++;

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -309,8 +309,10 @@ QuickSettingsList[]=TemplateSettings;Debug;site.ini;Template debug
 QuickSettingsList[]=TemplateSettings;ShowUsedTemplates;site.ini;List of used templates
 QuickSettingsList[]=DatabaseSettings;SQLOutput;site.ini;SQL debug output
 
-# Allow to adjust the edit URL in the list of used templates
-# %1$s is the value of $templateEditURI
+# Allow to adjust the edit URL in the list of used templates.
+# The code is using sprintf to render the URL and here you can
+# control where to fill the placeholders.
+# %1$s is the value of $templateEditURI (URL to a module/view showing an HTML editor)
 # %2$s is the value of $currentSiteAccess
 # %3$s is the value of $templateFileName
 UsedTemplateEditUrl=%1$s/(siteAccess)/%2$s

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -309,6 +309,12 @@ QuickSettingsList[]=TemplateSettings;Debug;site.ini;Template debug
 QuickSettingsList[]=TemplateSettings;ShowUsedTemplates;site.ini;List of used templates
 QuickSettingsList[]=DatabaseSettings;SQLOutput;site.ini;SQL debug output
 
+# Allow to adjust the edit URL in the list of used templates
+# %1$s is the value of $templateEditURI
+# %2$s is the value of $currentSiteAccess
+# %3$s is the value of $templateFileName
+UsedTemplateEditUrl=%1$s/(siteAccess)/%2$s
+
 [HTMLForms]
 ## Settings dealing with HTML forms and security aspects of it.
 # Setting to specify a secret for the csrf protection, it


### PR DESCRIPTION
**Background**
The list of Used Templates at the end of the debug output has actions (buttons) to edit a template. I opens an HTML editor in which you can make code edits. That requires you give write permissions to you template (security risk). Also, we never use that HTML editor but our IDE installed on our machines instead.
This pull request allows you to change the target URL of the edit button in the list of Used Templates. You can use a URL like phpstorm://<path to phpstorm>?file=<path to template file> to open the file in your PHPStorm IDE direktly.