### PR TITLE
Pagination of embedded media search on admin fixed

### DIFF
--- a/kernel/content/search.php
+++ b/kernel/content/search.php
@@ -150,7 +150,7 @@ if ( $http->hasVariable( 'Mode' ) && $http->variable( 'Mode' ) == 'browse' )
 //    $searchResult['RequestedURISuffix'] = $sys->serverVariable( "QUERY_STRING" );
 
 
-    $searchResult['RequestedURISuffix'] = 'SearchText=' . urlencode ( $searchText ) . ( ( $searchTimestamp > 0 ) ?  '&SearchTimestamp=' . $searchTimestamp : '' ) . '&BrowsePageLimit=' . $pageLimit . '&Mode=browse';
+    $searchResult['RequestedURISuffix'] = 'SearchText=' . urlencode ( $searchText ) . ( isset( $subTreeArray[0] ) ? '&SubTreeArray=' . $subTreeArray[0] : '' ) . ( ( $searchTimestamp > 0 ) ?  '&SearchTimestamp=' . $searchTimestamp : '' ) . '&BrowsePageLimit=' . $pageLimit . '&Mode=browse';
     return $Module->run( 'browse',array(),array( "NodeList" => $searchResult,
                                                  "Offset" => $Offset,
                                                  "NodeID" => isset( $subTreeArray[0] ) && $subTreeArray[0] != 1 ? $subTreeArray[0] : null  ) );


### PR DESCRIPTION
**Background**
Media content search results through embedded browse on admin site looses "media" context upon pagination and returns much larger search result. That's coming from the CSM project and is a bug in the legacy kernel.

**Testing instructions**
* In the media lib, do a search that returns more that one page of result sets (you may need to create some dummy content for that)
* On that result set, click on page 2
* Confirm you are still showing result sets in context of only the media lib
(Without this pull request, you would be in the context of the 'Content Structure' and it would potentially return more result entries)
