### PR TITLE
Allow to specify a mail transport class when sending an email

### DIFF
--- a/lib/ezutils/classes/ezmailtransport.php
+++ b/lib/ezutils/classes/ezmailtransport.php
@@ -25,15 +25,18 @@ class eZMailTransport
         return false;
     }
 
-    /*!
-     \static
-     Sends the contents of the email object \a $mail using the default transport.
-    */
-    static function send( eZMail $mail )
+    /**
+     * Sends the contents of the email object \a $mail using the default transport.
+     *
+     * @param eZMail $mail
+     * @param string $transportType
+     * @return boolean
+     */
+    static function send( eZMail $mail, $transportType = null )
     {
         $ini = eZINI::instance();
 
-        $transportType = trim( $ini->variable( 'MailSettings', 'Transport' ) );
+        $transportType = $transportType ? $transportType : trim( $ini->variable( 'MailSettings', 'Transport' ) );
 
         $optionArray = array( 'iniFile'      => 'site.ini',
                               'iniSection'   => 'MailSettings',


### PR DESCRIPTION
**Background**

CSM is using 2 different mail servers to send out emails:
1) For all sharing emails
2) For system relevant emails - like change password etc

The idea is that the sharing email service is likely to get marked at spam by email servers. So there is a chance people do not receive an email.

For system relevant emails, it is important that people receive the emails. Therefore we decided to use a 2nd email service that is not likely to get marked as spam.

**The solution**
In the settings you can only specify a single email transport service: 
[MailSettings]
Transport=<your transport service class>

I changed the function _send_ in the kernel; it know has an additional optional parameter that allows you to specify the Transport service. If specified, it will override what you have in the settings file. Therefore it will allow you to use as many transport services you want.

**Testing Instructions**
Testing this is pretty involved, you would need to configure a mailing service and then use that with a custom script or module/view. The code changes are pretty minimal, so I believe we get away by just looking at the code and confirming that it does what I described above. Also, we have it running in production for CSM for some time now.
