### PR TITLE
Allow to set custom tags as "hidden"

### DIFF
--- a/extension/ezoe/modules/ezoe/tags.php
+++ b/extension/ezoe/modules/ezoe/tags.php
@@ -113,12 +113,18 @@ if ( $tagName === 'custom' )
     if ( $contentIni->hasVariable( 'CustomTagSettings', 'IsInline' ) )
         $customInlineList = $contentIni->variable( 'CustomTagSettings', 'IsInline' );
 
+    if ( $contentIni->hasVariable( 'CustomTagSettings', 'IsHidden' ) )
+        $customIsHiddenList = $contentIni->variable( 'CustomTagSettings', 'IsHidden' );
+
     foreach( $contentIni->variable( 'CustomTagSettings', 'AvailableCustomTags' ) as $tag )
     {
-        if ( isset( $customTagDescription[$tag] ) )
-            $classList[$tag] = $customTagDescription[$tag];
-        else
-            $classList[$tag] = $tag;
+        if( !( isset( $customIsHiddenList[ $tag ] ) && $customIsHiddenList[ $tag ] == 'true' ) )
+        {
+            if ( isset( $customTagDescription[$tag] ) )
+                $classList[$tag] = $customTagDescription[$tag];
+            else
+                $classList[$tag] = $tag;
+        }
     }
 }
 else

--- a/extension/ezoe/modules/ezoe/tags.php
+++ b/extension/ezoe/modules/ezoe/tags.php
@@ -113,27 +113,25 @@ if ( $tagName === 'custom' )
     if ( $contentIni->hasVariable( 'CustomTagSettings', 'IsInline' ) )
         $customInlineList = $contentIni->variable( 'CustomTagSettings', 'IsInline' );
 
-	$customIsHiddenList = array();
+    $customIsHiddenList = array();
     if ( $contentIni->hasVariable( 'CustomTagSettings', 'IsHidden' ) )
-	{
-		$customIsHiddenList = $contentIni->variable( 'CustomTagSettings', 'IsHidden' );
-	}
-
-    var_dump( $customIsHiddenList );
-
+    {
+        $customIsHiddenList = $contentIni->variable( 'CustomTagSettings', 'IsHidden' );
+    }
+    
     foreach( $contentIni->variable( 'CustomTagSettings', 'AvailableCustomTags' ) as $tag )
     {
-    	if( !in_array( $tag, $customIsHiddenList ) )
-		{
-			if ( isset( $customTagDescription[$tag] ) )
-			{
-				$classList[$tag] = $customTagDescription[$tag];
-			}
-			else
-			{
-				$classList[$tag] = $tag;
-			}
-		}
+        if( !in_array( $tag, $customIsHiddenList ) )
+        {
+            if ( isset( $customTagDescription[$tag] ) )
+            {
+                $classList[$tag] = $customTagDescription[$tag];
+            }
+            else
+            {
+                $classList[$tag] = $tag;
+            }
+        }
     }
 }
 else

--- a/extension/ezoe/modules/ezoe/tags.php
+++ b/extension/ezoe/modules/ezoe/tags.php
@@ -113,18 +113,27 @@ if ( $tagName === 'custom' )
     if ( $contentIni->hasVariable( 'CustomTagSettings', 'IsInline' ) )
         $customInlineList = $contentIni->variable( 'CustomTagSettings', 'IsInline' );
 
+	$customIsHiddenList = array();
     if ( $contentIni->hasVariable( 'CustomTagSettings', 'IsHidden' ) )
-        $customIsHiddenList = $contentIni->variable( 'CustomTagSettings', 'IsHidden' );
+	{
+		$customIsHiddenList = $contentIni->variable( 'CustomTagSettings', 'IsHidden' );
+	}
+
+    var_dump( $customIsHiddenList );
 
     foreach( $contentIni->variable( 'CustomTagSettings', 'AvailableCustomTags' ) as $tag )
     {
-        if( !( isset( $customIsHiddenList[ $tag ] ) && $customIsHiddenList[ $tag ] == 'true' ) )
-        {
-            if ( isset( $customTagDescription[$tag] ) )
-                $classList[$tag] = $customTagDescription[$tag];
-            else
-                $classList[$tag] = $tag;
-        }
+    	if( !in_array( $tag, $customIsHiddenList ) )
+		{
+			if ( isset( $customTagDescription[$tag] ) )
+			{
+				$classList[$tag] = $customTagDescription[$tag];
+			}
+			else
+			{
+				$classList[$tag] = $tag;
+			}
+		}
     }
 }
 else

--- a/extension/ezoe/settings/content.ini.append.php
+++ b/extension/ezoe/settings/content.ini.append.php
@@ -31,7 +31,8 @@
 
 
 # Hides the custom tag in the dropdown to prevent editors from creating it
-IsHidden[]
+# For example: IsHidden[]=sub
+#IsHidden[]
 
 [paragraph]
 # Human-readable aliases for class names that will be displayed

--- a/extension/ezoe/settings/content.ini.append.php
+++ b/extension/ezoe/settings/content.ini.append.php
@@ -30,7 +30,8 @@
 #InlineImageIconPath[mashup]=images/tango/image-x-generic22.png
 
 
-
+# Hides the custom tag in the dropdown to prevent editors from creating it
+IsHidden[]
 
 [paragraph]
 # Human-readable aliases for class names that will be displayed


### PR DESCRIPTION
**Background**
You want to be able to hide ezoe custom tags in the UI - so that editor cannot use that custom tag anymore. But you don't want to completely remove the custom tag because your content already is using that custom tag. The solution is to allow to hide specific custom tags. Something like making them "deprecated".

**Solution**
In the settings you can specify which custom tag is hidden and it won't show in the editor UI anymore.

**Testing instructions**
* Change the settings and mark a custom tag as "hidden"
* Go to the admin UI and confirm that this custom tag is not available anymore in the dropdown box
