### PR TITLE
[EZP-24896] Email notification missing TO Receiver

### DIFF
--- a/kernel/classes/notification/ezmailnotificationtransport.php
+++ b/kernel/classes/notification/ezmailnotificationtransport.php
@@ -35,6 +35,8 @@ class eZMailNotificationTransport extends eZNotificationTransport
         if ( !$emailSender )
             $emailSender = $ini->variable( "MailSettings", "AdminEmail" );
 
+        $mail->addReceiver( 'undisclosed-recipients:;', '' );
+
         foreach ( $addressList as $addressItem )
         {
             $mail->extractEmail( $addressItem, $email, $name );


### PR DESCRIPTION
Email notification do not set the TO receiver - only multiple BCC receiver. Some email transport systems will complain about it. The solution is to set 'undisclosed-recipients:;' as the TO receiver.

Issue: https://jira.ez.no/browse/EZP-24896

**Testing Instructions**
* Login to the admin UI
* Go to dashboard
* Click My Notifications
* Add a notification subtree to your notifications
* In that subtree create a content node - like a folder
* Run following script on the server/vm:
* php runcronjobs.php frequent
* Confirm you received a notification email (check spam folder as well)
