### PR TITLE
Removing wrong encodeURI for thumbnail URLs in the admin interface

### DIFF
--- a/design/admin/javascript/ezajaxsubitems_datatable.js
+++ b/design/admin/javascript/ezajaxsubitems_datatable.js
@@ -60,7 +60,7 @@ var sortableSubitems = function () {
         }
 
         var thumbView = function(cell, record, column, data) {
-            var url = encodeURI(record.getData('thumbnail_url'));
+            var url = record.getData('thumbnail_url');
             if (url) {
                 var thBack = 'background: url(\'' + url.replace(/'/g, "\\'") + '\') no-repeat;';
                 var thWidth = ' width: ' + record.getData('thumbnail_width') + 'px;';


### PR DESCRIPTION
The encodeURI is only working by accident. The image URLs in ezp do not contain any characters that need encoding. So the output with or without encodeURI is always the same. It's causing an issue with the image server, because we allow other characters like Umlaute etc. The extra encodeURI is breaking the URL to the image.
eZ is using `eZURI::transformURI( $thumbUrl, true, null, false );` to build the thumbnail URL. I don't see why we'd need encodeURI before we set an image src tag.