### PR TITLE
Add the Copy button to the full view in the Administration Interface

### DIFF
--- a/design/admin/stylesheets/core.css
+++ b/design/admin/stylesheets/core.css
@@ -323,7 +323,7 @@ optgroup
     font-style: normal;
 }
 
-input.button, button, input.defaultbutton, input.button-disabled
+input.button, button, input.defaultbutton, input.button-disabled, a.button, a.button-disabled
 {
     font-family: Verdana, Arial, Helvetica, sans-serif;
     text-align: center;
@@ -333,9 +333,10 @@ input.button, button, input.defaultbutton, input.button-disabled
     font-weight: normal;
     padding-left: 0.25em;
     padding-right: 0.25em;
+    text-decoration: none;
 }
 
-input.defaultbutton
+input.defaultbutton, button.defaultbutton
 {
     font-weight: bold;
     padding-left: 0.45em;
@@ -343,7 +344,7 @@ input.defaultbutton
     color: #094564;
 }
 
-input.button-disabled, input.button[disabled="disabled"]
+input.button-disabled, input.button[disabled="disabled"], a.button-disabled, a.button[disabled="disabled"]
 {
     cursor: default;
     color: #888;
@@ -680,7 +681,7 @@ table.multioption
 {
     font-size:1em;
 }
-table.multioption input.button
+table.multioption input.button, table.multioption a.button
 {
     margin-left:0;
 }

--- a/design/admin/stylesheets/pagelayout.css
+++ b/design/admin/stylesheets/pagelayout.css
@@ -957,14 +957,14 @@ p.table-preferences a
     text-decoration: none;
 }
 
-input.button, input.defaultbutton, input.button-disabled
+input.button, input.defaultbutton, input.button-disabled, a.button, a.button-disabled
 {
     width: auto;
     overflow: visible;
     padding: 0.1em 0.5em;
 }
 
-input.button:hover
+input.button:hover, a.button:hover
 {
     border: 1px solid #999;
 }

--- a/design/admin/stylesheets/theme/rounded.css
+++ b/design/admin/stylesheets/theme/rounded.css
@@ -208,7 +208,7 @@ a.show-hide-tabs:hover
     height:25px;
 }
 
-.controlbar form .button-left .block input.button, .controlbar form .button-left .block input.button-disabled
+.controlbar form .button-left .block input.button, .controlbar form .button-left .block input.button-disabled, .controlbar form .button-left .block a.button, .controlbar form .button-left .block a.button-disabled
 {
     margin-top: -3px;
 }
@@ -240,7 +240,7 @@ a.show-hide-tabs:hover
     border-top: 1px dashed #ccc;
     font-size:1.5em;
 }
-.box-header select, .box-header input.button
+.box-header select, .box-header input.button, .box-header a.button
 {
 margin-top:7px;
 font-size:13px;
@@ -319,7 +319,7 @@ p.table-preferences :last-child
     border-right: 0px;
 }
 
-input.button, input.defaultbutton, input.button-disabled
+input.button, input.defaultbutton, input.button-disabled, a.button, a.button-disabled
 {
     color: #44484d;
     background: #fff;
@@ -335,12 +335,12 @@ input.button, input.defaultbutton, input.button-disabled
     transition: all 300ms ease;
 }
 
-input.defaultbutton, input.button-disabled, input.button[disabled="disabled"]
+input.defaultbutton, input.button-disabled, input.button[disabled="disabled"], a.button-disabled, a.button[disabled="disabled"]
 {
     background-color: #f5f5f5;
 }
 
-input.button:hover, input.button:focus {
+input.button:hover, input.button:focus, a.button:hover, a.button:focus {
     background-color: rgba(0, 0, 0, 0.1);
     color: black;
 }
@@ -366,7 +366,7 @@ input.defaultbutton:active {
     color: #ff8300;
 }
 
-input.button-disabled, input.button[disabled="disabled"]
+input.button-disabled, input.button[disabled="disabled"], a.button-disabled, a.button[disabled="disabled"]
 {
     color: #999;
     background: #fff;

--- a/design/admin/stylesheets/theme/rounded.css
+++ b/design/admin/stylesheets/theme/rounded.css
@@ -208,11 +208,6 @@ a.show-hide-tabs:hover
     height:25px;
 }
 
-.controlbar form .button-left .block input.button, .controlbar form .button-left .block input.button-disabled, .controlbar form .button-left .block a.button, .controlbar form .button-left .block a.button-disabled
-{
-    margin-top: -3px;
-}
-
 #controlbar-top .box-bc
 {
     border: 1px solid #ccc;

--- a/design/admin/templates/node/view/full.tpl
+++ b/design/admin/templates/node/view/full.tpl
@@ -98,6 +98,13 @@
     <input class="button-disabled" type="submit" name="MoveNodeButton" value="{'Move'|i18n( 'design/admin/node/view/full' )}" title="{'You do not have permission to move this item to another location.'|i18n( 'design/admin/node/view/full' )}" disabled="disabled" />
 {/if}
 
+{* Copy button. *}
+{if $node.object.can_edit}
+    <a class="button" href={concat("content/copy/",$node.contentobject_id)|ezurl}>{'Copy'|i18n( 'design/admin/node/view/full' )}</a>
+{else}
+    <a class="button-disabled" disabled="disabled" href="#">{'Copy'|i18n( 'design/admin/node/view/full' )}</a>
+{/if}
+
 {* Remove button. *}
 {if $node.can_remove}
     <input class="button" type="submit" name="ActionRemove" value="{'Remove'|i18n( 'design/admin/node/view/full' )}" title="{'Remove this item.'|i18n( 'design/admin/node/view/full' )}" />


### PR DESCRIPTION
Upstream pull request: https://github.com/ezsystems/ezpublish-legacy/pull/1413

Original description:
https://jira.ez.no/browse/EZP-29983

In the eZ back-end you have Edit / Move / Remove on the page you're viewing

But to copy, you have to initiate it from the "Sub items" window. No more! We will add the Copy button to the full view as well!
