### PR TITLE
Forcing a unique login per user row, making sure code can handle it

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -251,7 +251,10 @@ class eZUserType extends eZDataType
         else
         {
             // No "draft" for version 1 to avoid regression for existing code creating new users.
-            if ( $contentObjectAttribute->attribute( 'version' ) == '1' )
+            if ( 
+                $contentObjectAttribute->attribute( 'version' ) == '1' &&
+                ! $contentObjectAttribute->hasValidationError()
+            )
             {
                 $user->store();
                 $contentObjectAttribute->setContent( $user );
@@ -386,6 +389,7 @@ class eZUserType extends eZDataType
 
         if ( !empty( $serializedDraft ) )
         {
+            if( !$user ) $user = new eZUser();
             $user = $this->updateUserDraft( $user, $serializedDraft );
         }
 

--- a/update/database/mysql/lovestack/4.sql
+++ b/update/database/mysql/lovestack/4.sql
@@ -1,0 +1,7 @@
+# You may already have non-unique values in your ezuser database table.
+# Use following SQL statement to test and identify those instances:
+# SELECT login, COUNT(*) AS instances FROM ezuser GROUP BY login HAVING instances > 1;
+# You would need to manually resolve those duplicate rows - for example by editing the login values
+# Otherwise the following SQL statements will fail.
+DROP INDEX ezuser_login on ezuser;
+CREATE UNIQUE INDEX ezuser_login ON ezuser (login);


### PR DESCRIPTION
**Background**
The DB table `ezuser` allows non-unique values in the `login` column. That obviously does not make any sense. This pull request is changing the DB schema forcing unique values in the `login` column. It also adjusts the kernel code which is required to avoid fatal errors creating users in the admin backend.

**Testing Instructions**
1. Checkout branch
2. Update the DB schema: `php update/run.php -u ezpub -p ezpub -d ezpub`
3. Login to the admin UI
4. Create a new user account and send for publishing
5. Create another new user account - make sure to pick exactly the same value for the 'username' field.
6. Confirm that you don't get a 500 fatal error. You should see an input validation error message, saying that the username already exists.