### PR TITLE
Bringing the initial DB schema/data to version 5 of the the lovestack DB schema version

### DIFF
--- a/kernel/sql/common/cleandata.sql
+++ b/kernel/sql/common/cleandata.sql
@@ -36949,7 +36949,14 @@ INSERT INTO ezsite_data (
   value
 ) VALUES (
   'ezpublish-version',
-  '5.90.0alpha1'
+  'lovestack'
+);
+INSERT INTO ezsite_data (
+  name,
+  value
+) VALUES (
+  'db-schema-version',
+  '5'
 );
 
 INSERT INTO ezurl (

--- a/kernel/sql/mysql/kernel_schema.sql
+++ b/kernel/sql/mysql/kernel_schema.sql
@@ -1608,7 +1608,7 @@ CREATE TABLE ezuser (
   password_hash varchar(255) default NULL,
   password_hash_type int(11) NOT NULL default '1',
   PRIMARY KEY  (contentobject_id),
-  KEY ezuser_login (login)
+  UNIQUE KEY ezuser_login (login)
 ) ENGINE=InnoDB;
 
 

--- a/kernel/sql/postgresql/kernel_schema.sql
+++ b/kernel/sql/postgresql/kernel_schema.sql
@@ -4013,7 +4013,7 @@ CREATE INDEX ezurlalias_ml_text_lang ON ezurlalias_ml USING btree (text, lang_ma
 
 
 
-CREATE INDEX ezuser_login ON ezuser USING btree (login);
+CREATE UNIQUE INDEX ezuser_login ON ezuser USING btree (login);
 
 
 

--- a/share/db_data.dba
+++ b/share/db_data.dba
@@ -21875,7 +21875,12 @@ keywords=cms, publish, e-commerce, content management, development framework',
       1 => 
       array (
         0 => 'ezpublish-version',
-        1 => '5.90.0alpha1',
+        1 => 'lovestack',
+      ),
+      2 =>
+      array (
+        0 => 'db-schema-version',
+        1 => '5',
       ),
     ),
   ),

--- a/share/db_schema.dba
+++ b/share/db_schema.dba
@@ -7303,7 +7303,7 @@ $schema = array (
       ),
       'ezuser_login' => 
       array (
-        'type' => 'non-unique',
+        'type' => 'unique',
         'fields' => 
         array (
           0 => 'login',

--- a/update/database/mysql/lovestack/1.sql
+++ b/update/database/mysql/lovestack/1.sql
@@ -1,2 +1,1 @@
 UPDATE ezsite_data SET value='lovestack' WHERE name='ezpublish-version';
-UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';

--- a/update/database/mysql/lovestack/3.sql
+++ b/update/database/mysql/lovestack/3.sql
@@ -2,4 +2,4 @@
 -- EZP-28881: Add a field to support "date object was trashed"
 --
 
-ALTER TABLE ezcontentobject_trash add  trashed int(11) NOT NULL DEFAULT '0';
+ALTER TABLE ezcontentobject_trash add trashed int(11) NOT NULL DEFAULT '0';

--- a/update/database/postgresql/lovestack/1.sql
+++ b/update/database/postgresql/lovestack/1.sql
@@ -1,2 +1,1 @@
 UPDATE ezsite_data SET value='lovestack' WHERE name='ezpublish-version';
-UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';

--- a/update/database/postgresql/lovestack/3.sql
+++ b/update/database/postgresql/lovestack/3.sql
@@ -2,4 +2,4 @@
 -- EZP-28881: Add a field to support "date object was trashed"
 --
 
-ALTER TABLE ezcontentobject_trash add  trashed integer DEFAULT 0 NOT NULL;
+ALTER TABLE ezcontentobject_trash add trashed integer DEFAULT 0 NOT NULL;


### PR DESCRIPTION
**Background**
There is a base DB schema and DB data dump when you install eZ Publish. The installation wizard is using this file `share/db_data.dba`.
Additionally we do have update scripts allowing a developer to progressively bring the DB up to date with the code version (see 'update/run.php').
This pull request is updating the initial DB schema/data to the lovestack version 5. That was required due to the initial DB schema update in this pull request: https://github.com/ezsystems/ezpublish-legacy/pull/1393
It was breaking the update process (update/run.php) - changes have been already implemented in a fresh lovestack installation.

**Testing instructions**
1. Install a fresh lovestack instance
2. Run the update script and confirm it's already on version 5 (doing no changes to the DB)
3. Confirm you see the correct data in the ezsite data table: http://devmanage.lovestack.mugo.ca/sitedata/list - it should say 'lovestack' for the ezpublish-version
