### PR TITLE
Update ezfind release (composer)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "ezsystems/ezflow-ls-extension": "~5.3",
         "ezsystems/ezwt-ls-extension": "~5.3",
         "symfony/polyfill-php73":  "^1.9",
-        "mugoweb/ezfind": "^2019.03",
+        "mugoweb/ezfind": "^2020.04",
         "zetacomponents/archive": "~1.5",
         "zetacomponents/authentication": "~1.4",
         "zetacomponents/authentication-database-tiein": "~1.2",


### PR DESCRIPTION
Our eZ Find fork had a few updates since the last release.
The latest release is v2020.04.1

We should update our eZ Publish fork to include this new release.