### PR TITLE
Make DocBlock less restrictive for template variable in eZTemplate::setVariable()

### DIFF
--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -1487,7 +1487,7 @@ class eZTemplate
      * Sets the template variable $var to the value $val.
      *
      * @param string $var
-     * @param string $val
+     * @param $val
      * @param string $namespace (optional)
      * @param bool $scopeSafe If true, will assure that $var is not overridden for $namespace. False by default
      */

--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -1487,7 +1487,7 @@ class eZTemplate
      * Sets the template variable $var to the value $val.
      *
      * @param string $var
-     * @param $val
+     * @param mixed $val
      * @param string $namespace (optional)
      * @param bool $scopeSafe If true, will assure that $var is not overridden for $namespace. False by default
      */


### PR DESCRIPTION
IDE was complaining when setting an object as a template variable