### PR TITLE
EZP-31040: Remote Code Execution in file uploads

### DIFF
--- a/autoload/ezp_kernel.php
+++ b/autoload/ezp_kernel.php
@@ -172,6 +172,7 @@ return array(
       'eZExtensionPackageHandler'                          => 'kernel/classes/packagehandlers/ezextension/ezextensionpackagehandler.php',
       'eZFSFileHandler'                                    => 'kernel/classes/clusterfilehandlers/ezfsfilehandler.php',
       'eZFile'                                             => 'lib/ezfile/classes/ezfile.php',
+      'eZFileExtensionBlackListValidator'                  => 'lib/ezutils/classes/ezfileextensionblacklistvalidator.php',
       'eZFileHandler'                                      => 'lib/ezfile/classes/ezfilehandler.php',
       'eZFilePackageHandler'                               => 'kernel/classes/packagehandlers/ezfile/ezfilepackagehandler.php',
       'eZFilePassthroughHandler'                           => 'kernel/classes/binaryhandlers/ezfilepassthrough/ezfilepassthroughhandler.php',

--- a/kernel/class/copy.php
+++ b/kernel/class/copy.php
@@ -89,4 +89,4 @@ switch ( $classRedirect )
     } break;
 }
 
-?>
+

--- a/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
+++ b/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
@@ -1094,7 +1094,7 @@ class eZImageAliasHandler
      * @param eZHTTPFile $httpFile
      * @param string $imageAltText Optional image ALT text
      *
-     * @return TODO: FIXME
+     * @return bool
      */
     function initializeFromHTTPFile( $httpFile, $imageAltText = false )
     {

--- a/kernel/classes/datatypes/ezimage/ezimagetype.php
+++ b/kernel/classes/datatypes/ezimage/ezimagetype.php
@@ -201,7 +201,7 @@ class eZImageType extends eZDataType
      * @param $http: http object
      * @param $base:
      * @param $contentObjectAttribute: content object attribute being validated
-     * @return validation result- eZInputValidator::STATE_INVALID or eZInputValidator::STATE_ACCEPTED
+     * @return int result- eZInputValidator::STATE_INVALID or eZInputValidator::STATE_ACCEPTED
      *
      * @see kernel/classes/eZDataType#validateObjectAttributeHTTPInput($http, $base, $objectAttribute)
      */
@@ -355,6 +355,7 @@ class eZImageType extends eZDataType
 
     function storeObjectAttribute( $contentObjectAttribute )
     {
+        /** @var eZImageAliasHandler $imageHandler */
         $imageHandler = $contentObjectAttribute->attribute( 'content' );
         if ( $imageHandler )
         {

--- a/kernel/classes/datatypes/ezmedia/ezmediatype.php
+++ b/kernel/classes/datatypes/ezmedia/ezmediatype.php
@@ -27,6 +27,7 @@ class eZMediaType extends eZDataType
     {
         parent::__construct( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Media", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
+        $this->FileExtensionBlackListValidator = new eZFileExtensionBlackListValidator();
     }
 
     /*!
@@ -181,14 +182,36 @@ class eZMediaType extends eZDataType
         $maxSize = 1024 * 1024 * $classAttribute->attribute( self::MAX_FILESIZE_FIELD );
         $mustUpload = false;
 
-        if ( $contentObjectAttribute->validateIsRequired() )
+        $contentObjectAttributeID = $contentObjectAttribute->attribute( 'id' );
+        $version = $contentObjectAttribute->attribute( 'version' );
+        $media = eZMedia::fetch( $contentObjectAttributeID, $version );
+        $extensionsBlackList = implode(', ', $this->FileExtensionBlackListValidator->extensionsBlackList() );
+        if ( $media === null || !$media->attribute( 'filename' ) )
         {
-            $contentObjectAttributeID = $contentObjectAttribute->attribute( "id" );
-            $version = $contentObjectAttribute->attribute( "version" );
-            $media = eZMedia::fetch( $contentObjectAttributeID, $version );
-            if ( $media === null || !$media->attribute( 'filename' ) )
+            if ( $contentObjectAttribute->validateIsRequired() )
             {
                 $mustUpload = true;
+            }
+        }
+        else
+        {
+            $state = $this->FileExtensionBlackListValidator->validate( $media->attribute( 'filename' ) );
+            if ( $state === eZInputValidator::STATE_INVALID || $state === eZInputValidator::STATE_INTERMEDIATE )
+            {
+                $contentObjectAttribute->setValidationError( ezpI18n::tr( 'kernel/classes/datatypes',
+                    "A valid file is required. The following file extensions are blacklisted: $extensionsBlackList" ) );
+                return eZInputValidator::STATE_INVALID;
+            }
+        }
+
+        if ( isset( $_FILES[$httpFileName] ) && $_FILES[$httpFileName]['tmp_name'] !== '')
+        {
+            $state = $this->FileExtensionBlackListValidator->validate( $_FILES[$httpFileName]['name'] );
+            if ( $state === eZInputValidator::STATE_INVALID || $state === eZInputValidator::STATE_INTERMEDIATE )
+            {
+                $contentObjectAttribute->setValidationError( ezpI18n::tr( 'kernel/classes/datatypes',
+                    "A valid file is required. The following file extensions are blacklisted: $extensionsBlackList" ) );
+                return eZInputValidator::STATE_INVALID;
             }
         }
 
@@ -273,6 +296,11 @@ class eZMediaType extends eZDataType
     {
 
         eZMediaType::checkFileUploads();
+
+        if ( $this->validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute ) !== eZInputValidator::STATE_ACCEPTED )
+        {
+            return false;
+        }
 
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
         $player = $classAttribute->attribute( "data_text1" );
@@ -799,6 +827,10 @@ class eZMediaType extends eZDataType
     {
         return true;
     }
+
+    /// \privatesection
+    /// The file extension blacklist validator
+    private $FileExtensionBlackListValidator;
 }
 
 eZDataType::register( eZMediaType::DATA_TYPE_STRING, "eZMediaType" );

--- a/lib/ezutils/classes/ezfileextensionblacklistvalidator.php
+++ b/lib/ezutils/classes/ezfileextensionblacklistvalidator.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * File containing the eZFileExtensionBlackListValidator class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ * @package lib
+ */
+
+/*!
+  \class eZFileExtensionBlackListValidator ezfileextensionblacklistvalidator.php
+  \brief The class eZFileExtensionBlackListValidator validates file extensions based on a blacklist.
+*/
+
+class eZFileExtensionBlackListValidator extends eZInputValidator
+{
+    /*!
+     Constructor
+    */
+    function __construct()
+    {
+        $fileIni = eZINI::instance('file.ini');
+        $this->constraints['extensionsBlackList'] = $fileIni->variable('FileSettings','FileExtensionBlackList');
+    }
+
+    /*!
+     Tries to validate to the filename \a $filename and returns one of the validator states
+     eZInputValidator::STATE_ACCEPTED, eZInputValidator::STATE_INTERMEDIATE or
+     eZInputValidator::STATE_INVALID.
+    */
+    function validate( $filename )
+    {
+        if (
+            pathinfo($filename, PATHINFO_BASENAME) !== $filename ||
+            in_array(strtolower(pathinfo($filename, PATHINFO_EXTENSION)), $this->constraints['extensionsBlackList'], true)
+        ) {
+            return eZInputValidator::STATE_INVALID;
+        }
+
+        return eZInputValidator::STATE_ACCEPTED;
+    }
+
+    /*!
+     Return the list of blacklisted file extensions.
+    */
+    function extensionsBlackList()
+    {
+        return $this->constraints['extensionsBlackList'];
+    }
+
+    /// \privatesection
+    protected $constraints = array(
+        'extensionsBlackList' => array(),
+    );
+}

--- a/settings/file.ini
+++ b/settings/file.ini
@@ -33,6 +33,17 @@ Handlers[gzip]=ezgzipcompressionhandler
 Handlers[gzipzlib]=ezgzipzlibcompressionhandler
 Handlers[gzipshell]=ezgzipshellcompressionhandler
 
+# The file extension blacklist is used to validate uploaded files.
+# File types on the blacklist are rejected, for security or other reasons.
+FileExtensionBlackList[]
+FileExtensionBlackList[]=php
+FileExtensionBlackList[]=php3
+FileExtensionBlackList[]=phar
+FileExtensionBlackList[]=phpt
+FileExtensionBlackList[]=pht
+FileExtensionBlackList[]=phtml
+FileExtensionBlackList[]=pgif
+
 [ClusteringSettings]
 # Cluster file handler.
 # Since 4.1 name of the filehandlers have changed


### PR DESCRIPTION
This commit is from upstream:
https://github.com/ezsystems/ezpublish-legacy/commit/8c9b70662785b53ebca13f7c7fdaece05bfb132f

The "file upload"/"ezmedia upload" (ezfile and ezmedia attributes) is now protected and won't allow any file uploads with the .php and similar file extensions. It's not directly a problem: uploaded files are protected by the rewrite rules, so you cannot directly access the uploaded file - for example /var/site/storage/original/application/33ab5a38e9bf383eb9506ed35435dbc0.php
But maybe the rewrite rules are not correctly set, then it makes sense to do the extra check by file extension.

In upstream the blacklist of file extensions is also active for image uploads but it's not required and I did not merge the code into our fork.

We added input validation that reads the mimetype of the uploaded image file. You can still trick the system by uploading a file like this:

GIF89a<?php
echo 'hacked';
?>

If you use the file name test.gif, the system accepts it. But when it tries to render it, it just fails (no valid gif file - apache is not processing the php code).
If you use a file name test.php, the system would still accept it. But it changes the file extension from .php to .bin. Apache won't execute the php code inside the file. The browser will just download the .bin file.

Here are the relevant code locations:
Reading mimetype:
https://github.com/mugoweb/ezpublish-legacy/blob/master/lib/ezutils/classes/ezmimetype.php#L197
Changing file extension:
https://github.com/mugoweb/ezpublish-legacy/blob/master/lib/ezutils/classes/ezmimetype.php#L141
