### PR TITLE
Add option 'trim' to the ezstring datatype

### DIFF
--- a/design/standard/templates/class/datatype/edit/ezstring.tpl
+++ b/design/standard/templates/class/datatype/edit/ezstring.tpl
@@ -11,3 +11,16 @@
     <label>{'Max string length'|i18n( 'design/standard/class/datatype' )}:</label>
     <input type="text" name="ContentClass_ezstring_max_string_length_{$class_attribute.id}" value="{$class_attribute.data_int1}" size="5" maxlength="5" />&nbsp;{'characters'|i18n( 'design/standard/class/datatype' )}
 </div>
+
+{* Trim input *}
+<div class="block">
+    <label>{'Trim white spaces left and right'|i18n( 'design/standard/class/datatype' )}:</label>
+    <input
+            type="checkbox"
+            name="ContentClass_ezstring_trim_{$class_attribute.id}"
+            value="1"
+            {if $class_attribute.data_int2}
+                checked="checked"
+            {/if}
+    />
+</div>

--- a/design/standard/templates/class/datatype/view/ezstring.tpl
+++ b/design/standard/templates/class/datatype/view/ezstring.tpl
@@ -15,4 +15,15 @@
         <p>{$class_attribute.data_int1}&nbsp;{'characters'|i18n( 'design/standard/class/datatype' )}</p>
     </div>
 
+    <div class="element">
+        <label>{'Trim white spaces left and right'|i18n( 'design/standard/class/datatype' )}:</label>
+        <p>
+            {if $class_attribute.data_int2}
+                {'Yes'|i18n( 'design/standard/class/datatype' )}
+            {else}
+                {'No'|i18n( 'design/standard/class/datatype' )}
+            {/if}
+        </p>
+    </div>
+
 </div>

--- a/kernel/classes/datatypes/ezstring/ezstringtype.php
+++ b/kernel/classes/datatypes/ezstring/ezstringtype.php
@@ -272,6 +272,9 @@ class eZStringType extends eZDataType
         $defaultValueName = $base . self::DEFAULT_STRING_VARIABLE . $classAttribute->attribute( 'id' );
         $trimName = $base . self::TRIM_VARIABLE . $classAttribute->attribute( 'id' );
 
+        // This function is also called when creating a new content class version
+        $isSubmit = $http->hasPostVariable( $maxLenName );
+
         if ( $http->hasPostVariable( $maxLenName ) )
         {
             $maxLenValue = $http->postVariable( $maxLenName );
@@ -282,9 +285,10 @@ class eZStringType extends eZDataType
             $defaultValueValue = $http->postVariable( $defaultValueName );
             $classAttribute->setAttribute( self::DEFAULT_STRING_FIELD, $defaultValueValue );
         }
-        if ( $http->hasPostVariable( $trimName ) )
+
+        if( $isSubmit )
         {
-            $classAttribute->setAttribute( self::TRIM_FIELD, 1 );
+            $classAttribute->setAttribute( self::TRIM_FIELD, (int)$http->hasPostVariable( $trimName ) );
         }
 
         return true;

--- a/kernel/classes/datatypes/ezstring/ezstringtype.php
+++ b/kernel/classes/datatypes/ezstring/ezstringtype.php
@@ -158,19 +158,19 @@ class eZStringType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-	/**
-	 * Fetches the http post var string input and stores it in the data instance.
-	 * @param $http
-	 * @param string $base
-	 * @param eZContentObjectAttribute $contentObjectAttribute
-	 * @return bool|void
-	 */
+    /**
+     * Fetches the http post var string input and stores it in the data instance.
+     * @param $http
+     * @param string $base
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return bool|void
+     */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
-		$classAttribute = $contentObjectAttribute->contentClassAttribute();
-		$doTrim = (bool)$classAttribute->attribute( self::TRIM_FIELD );
+        $classAttribute = $contentObjectAttribute->contentClassAttribute();
+        $doTrim = (bool)$classAttribute->attribute( self::TRIM_FIELD );
 
-		if ( $http->hasPostVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) )
+        if ( $http->hasPostVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) )
         {
             $data = $http->postVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) );
             $data = $doTrim ? trim( $data ) : $data;

--- a/kernel/classes/datatypes/ezstring/ezstringtype.php
+++ b/kernel/classes/datatypes/ezstring/ezstringtype.php
@@ -30,6 +30,8 @@ class eZStringType extends eZDataType
     const MAX_LEN_VARIABLE = '_ezstring_max_string_length_';
     const DEFAULT_STRING_FIELD = "data_text1";
     const DEFAULT_STRING_VARIABLE = "_ezstring_default_value_";
+    const TRIM_FIELD = 'data_int2';
+    const TRIM_VARIABLE = '_ezstring_trim_';
 
     /*!
      Initializes with a string id and a description.
@@ -90,19 +92,26 @@ class eZStringType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-
+    /**
+     * @param $http
+     * @param $base
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return int
+     */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
+        $inputRequired = $contentObjectAttribute->validateIsRequired();
 
         if ( $http->hasPostVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) )
         {
+            // Only white spaces never works if input is required
             $data = trim( $http->postVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) );
 
             if ( $data == "" )
             {
-                if ( !$classAttribute->attribute( 'is_information_collector' ) and
-                     $contentObjectAttribute->validateIsRequired() )
+                if ( !$classAttribute->attribute( 'is_information_collector' ) &&
+                    $inputRequired )
                 {
                     $contentObjectAttribute->setValidationError( ezpI18n::tr( 'kernel/classes/datatypes',
                                                                          'Input required.' ) );
@@ -114,7 +123,7 @@ class eZStringType extends eZDataType
                 return $this->validateStringHTTPInput( $data, $contentObjectAttribute, $classAttribute );
             }
         }
-        else if ( !$classAttribute->attribute( 'is_information_collector' ) and $contentObjectAttribute->validateIsRequired() )
+        else if ( !$classAttribute->attribute( 'is_information_collector' ) && $inputRequired )
         {
             $contentObjectAttribute->setValidationError( ezpI18n::tr( 'kernel/classes/datatypes', 'Input required.' ) );
             return eZInputValidator::STATE_INVALID;
@@ -149,14 +158,22 @@ class eZStringType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
+	/**
+	 * Fetches the http post var string input and stores it in the data instance.
+	 * @param $http
+	 * @param string $base
+	 * @param eZContentObjectAttribute $contentObjectAttribute
+	 * @return bool|void
+	 */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
-        if ( $http->hasPostVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) )
+		$classAttribute = $contentObjectAttribute->contentClassAttribute();
+		$doTrim = (bool)$classAttribute->attribute( self::TRIM_FIELD );
+
+		if ( $http->hasPostVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) )
         {
             $data = $http->postVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) );
+            $data = $doTrim ? trim( $data ) : $data;
             $contentObjectAttribute->setAttribute( 'data_text', $data );
             return true;
         }
@@ -253,6 +270,8 @@ class eZStringType extends eZDataType
     {
         $maxLenName = $base . self::MAX_LEN_VARIABLE . $classAttribute->attribute( 'id' );
         $defaultValueName = $base . self::DEFAULT_STRING_VARIABLE . $classAttribute->attribute( 'id' );
+        $trimName = $base . self::TRIM_VARIABLE . $classAttribute->attribute( 'id' );
+
         if ( $http->hasPostVariable( $maxLenName ) )
         {
             $maxLenValue = $http->postVariable( $maxLenName );
@@ -261,9 +280,13 @@ class eZStringType extends eZDataType
         if ( $http->hasPostVariable( $defaultValueName ) )
         {
             $defaultValueValue = $http->postVariable( $defaultValueName );
-
             $classAttribute->setAttribute( self::DEFAULT_STRING_FIELD, $defaultValueValue );
         }
+        if ( $http->hasPostVariable( $trimName ) )
+        {
+            $classAttribute->setAttribute( self::TRIM_FIELD, 1 );
+        }
+
         return true;
     }
 
@@ -295,7 +318,6 @@ class eZStringType extends eZDataType
     {
         return $contentObjectAttribute->setAttribute( 'data_text', $string );
     }
-
 
     /*!
      Returns the content of the string for use as a title
@@ -390,5 +412,3 @@ class eZStringType extends eZDataType
 }
 
 eZDataType::register( eZStringType::DATA_TYPE_STRING, 'eZStringType' );
-
-?>


### PR DESCRIPTION
If you add an attribute 'Text line' (ezstring) to a class, you are now able to check an option 'Trim input left and right'.
Any input for that attribute is getting trimmed (if the option is enabled).

**Testing instructions**
* create or use a class that has a 'Text line' attribute
* Make sure you enable the option 'Trim input left and right'
* Edit/Create an object of that class and enter a string with white spaces at the beginning and the end of the string
* Send for publishing
* Confirm the entered string was trimmed

**Site note**
It's not affecting input validation. If the input is required, the original code was always trimming the text. In other words, only white spaces won't bypass the input validation independent of the new option 'Trim input left and right'
