### PR TITLE
Allowing custom eZNamePatternResolver classes

### DIFF
--- a/design/admin/templates/class/edit.tpl
+++ b/design/admin/templates/class/edit.tpl
@@ -114,7 +114,10 @@
 
     {* Object name pattern. *}
     <div class="block">
-    <label for="ContentClass_contentobject_name">{'Object name pattern'|i18n( 'design/admin/class/edit' )}:</label>
+    <label for="ContentClass_contentobject_name">
+        {'Object name pattern'|i18n( 'design/admin/class/edit' )}:
+        <small>Examples '&lt;title&gt;' or '&lt;short|title&gt;' or '{ldelim}CustomEzNamepatternResolverClass{rdelim}'</small>
+    </label>
     <input class="box" type="text" id="ContentClass_contentobject_name" name="ContentClass_contentobject_name" size="30" value="{$class.contentobject_name|wash}" title="{'Use this field to configure how the name of the objects are generated. Type in the identifiers of the attributes that should be used. The identifiers must be enclosed in angle brackets. Text outside angle brackets will be included as it is shown here.'|i18n( 'design/admin/class/edit' )|wash}" />
     </div>
 

--- a/doc/features/l10.0/CustomEzNamePatternResolver.md
+++ b/doc/features/l10.0/CustomEzNamePatternResolver.md
@@ -1,0 +1,29 @@
+Object name pattern and URL alias name pattern
+=
+
+Existing functionality
+-
+As an admin user, you can edit a class definition in the admin UI.
+There are 2 text fields allowing you to specify:
+* Object name pattern
+* URL alias name pattern 
+
+Typically, you specify an attribute of that class. The attribute value
+is used to generate the object name (URL alias name). It is
+simplifying the string in order to build valid object/URL alias names.
+
+New feature
+-
+As an admin user, you can now specify a PHP class which
+is responsible to generate the object/URL alias name.
+While editing the content class in the admin uI, you can
+specify that PHP class in the 2 text fields for
+object/URL alias name pattern.
+
+Here is an example value: {MyCustomEzNamePatternResolver}
+
+The system will get an instance of your PHP class and calls
+the `function resolveNamePattern`. You have to make sure that
+the PHP class 'MyCustomEzNamePatternResolver' is a subclass of
+'eZNamePatternResolver'. Best pratice is to put that class
+in your eZ Publish extension under the directory 'classes'.

--- a/kernel/classes/ezcontentclass.php
+++ b/kernel/classes/ezcontentclass.php
@@ -1404,10 +1404,14 @@ You will need to change the class of the node by using the swap functionality.' 
         {
             $length = self::CONTENT_OBJECT_NAME_MAX_LENGTH;
         }
-        $nameResolver = new eZNamePatternResolver( $contentObjectNamePattern, $contentObject, $version, $translation );
-        $contentObjectName = $nameResolver->resolveNamePattern( $length, $sequence );
 
-        return $contentObjectName;
+        return eZNamePatternResolver::instance( $contentObjectNamePattern )->resolveNamePattern(
+            $contentObject,
+            $version,
+            $translation,
+            $length,
+            $sequence
+        );
     }
 
     /**
@@ -1431,51 +1435,13 @@ You will need to change the class of the node by using the swap functionality.' 
         }
 
         $length = (int) eZINI::instance()->variable('URLTranslator', 'UrlAliasNameLimit');
-        $nameResolver = new eZNamePatternResolver( $urlAliasNamePattern, $contentObject, $version, $translation );
-        $urlAliasName = $nameResolver->resolveNamePattern( $length );
 
-        return $urlAliasName;
-    }
-
-    /*!
-     Generates a name for the content object based on the content object name pattern
-     and data map of an object.
-    */
-    function buildContentObjectName( $contentObjectName, $dataMap, $tmpTags = false )
-    {
-        preg_match_all( "|<[^>]+>|U",
-                        $contentObjectName,
-                        $tagMatchArray );
-
-        foreach ( $tagMatchArray[0] as $tag )
-        {
-            $tagName = str_replace( "<", "", $tag );
-            $tagName = str_replace( ">", "", $tagName );
-
-            $tagParts = explode( '|', $tagName );
-
-            $namePart = "";
-            foreach ( $tagParts as $name )
-            {
-                // get the value of the attribute to use in name
-                if ( isset( $dataMap[$name] ) )
-                {
-                    $namePart = $dataMap[$name]->title();
-                    if ( $namePart != "" )
-                        break;
-                }
-                elseif ( $tmpTags && isset( $tmpTags[$name] ) && $tmpTags[$name] != '' )
-                {
-                    $namePart = $tmpTags[$name];
-                    break;
-                }
-
-            }
-
-            // replace tag with object name part
-            $contentObjectName = str_replace( $tag, $namePart, $contentObjectName );
-        }
-        return $contentObjectName;
+        return eZNamePatternResolver::instance( $urlAliasNamePattern )->resolveNamePattern(
+            $contentObject,
+            $version,
+            $translation,
+            $length
+        );
     }
 
     /*!

--- a/tests/tests/kernel/classes/eznamepatternresolver_regression.php
+++ b/tests/tests/kernel/classes/eznamepatternresolver_regression.php
@@ -96,8 +96,14 @@ class eZNamePatternResolverRegression extends ezpTestCase
             ->will( $this->returnValue( $name ) );
 
 
-        $resolver = new eZNamePatternResolver( $namePattern, $contentObjectMock );
-        $result = $resolver->resolveNamePattern( $limit, $sequence );
+        $resolver = eZNamePatternResolver::instance( $namePattern );
+        $result = $resolver->resolveNamePattern(
+        	$contentObjectMock,
+			false,
+			false,
+			$limit,
+			$sequence
+		);
 
         $this->assertEquals( $expects, $result );
     }


### PR DESCRIPTION
The idea is to allow more options how the system is generating the content object names. Currently, you edit a content class definition in the admin UI and specify the attributes, you would like to use for the object name. For example:

`<short_title|title>`

That would use the attribute `short_title` to generate the object name. If the attribute is empty, it would fall back to the title attribute.

This pull request is giving you more flexibility: You can specify a PHP class that is responsible to build the content object name. You would need to specify that PHP class in the same text field when editing a class definition. An example value is:

`{FancyDateNamePatternResolver}<birthday>`

The CMS would try to find a PHP class called FancyDateNamePatternResolver and verifies that it is a subclass of `eZNamePatternResolver`. In that custom class you would need to implement that returns the object name. The class has various variable available to build that name: contentobject, version, translation etc.

This pull request is also removing the function `buildContentObjectName`. Nothing in the framework is calling that function. I believe eZ Systems left the function in the code for backwards compatibility reasons. The chance that an extension is using that function is almost zero.

