### PR TITLE
Use php rawurlencode instead of urlencode

### DIFF
--- a/settings/template.ini
+++ b/settings/template.ini
@@ -50,8 +50,8 @@ EmailAtText=<span class="spamfilter">SPAMFILTER</span>@
 # Note: Only one parameter (the value) is supported and php function must
 #       return result by value and not by reference.
 PHPOperatorList[]
-PHPOperatorList[urlencode]=rawurlencode
-PHPOperatorList[urldecode]=rawurldecode
+PHPOperatorList[urlencode]=urlencode
+PHPOperatorList[urldecode]=urldecode
 PHPOperatorList[rawurlencode]=rawurlencode
 PHPOperatorList[rawurldecode]=rawurldecode
 

--- a/settings/template.ini
+++ b/settings/template.ini
@@ -50,8 +50,10 @@ EmailAtText=<span class="spamfilter">SPAMFILTER</span>@
 # Note: Only one parameter (the value) is supported and php function must
 #       return result by value and not by reference.
 PHPOperatorList[]
-PHPOperatorList[urlencode]=urlencode
-PHPOperatorList[urldecode]=urldecode
+PHPOperatorList[urlencode]=rawurlencode
+PHPOperatorList[urldecode]=rawurldecode
+PHPOperatorList[rawurlencode]=rawurlencode
+PHPOperatorList[rawurldecode]=rawurldecode
 
 [AutoLinkOperator]
 # The maximum number of characters to show in autolink


### PR DESCRIPTION
It's very unlikely that you want to use the PHP function `urlencode`. In almost all case, the PHP function `rawurlencode` is what you want to use (compare https://stackoverflow.com/questions/996139/urlencode-vs-rawurlencode).

This pull request is changing the template operator to use `rawurlencode` and `rawurldecode`.