### PR TITLE
Proposing bigger log files by default

### DIFF
--- a/lib/ezfile/classes/ezlog.php
+++ b/lib/ezfile/classes/ezlog.php
@@ -19,7 +19,7 @@
 class eZLog
 {
     const MAX_LOGROTATE_FILES = 3;
-    const MAX_LOGFILE_SIZE = 2048000; // 2000*1024
+    const MAX_LOGFILE_SIZE = 2097152; // 2MB
 
     /*!
      \static

--- a/lib/ezfile/classes/ezlog.php
+++ b/lib/ezfile/classes/ezlog.php
@@ -19,7 +19,7 @@
 class eZLog
 {
     const MAX_LOGROTATE_FILES = 3;
-    const MAX_LOGFILE_SIZE = 204800; // 200*1024
+    const MAX_LOGFILE_SIZE = 2048000; // 2000*1024
 
     /*!
      \static


### PR DESCRIPTION
By default the log file sizes in ezp have a maximum size of 200KB. With 3 log file rotations, you'll get a maximum of 600KB worth of log information (per severity).
This pull request proposes bigger log files (2MB). The downside is more disk usage: 6MB per severity (error, warning, notice etc)