### PR TITLE
Broken dashboard widget for latest forum news removed, maintenance template adjusted

### DIFF
--- a/design/admin/templates/content/dashboard.tpl
+++ b/design/admin/templates/content/dashboard.tpl
@@ -1,7 +1,7 @@
 {* set scope=global persistent_variable=hash('extra_menu', false()) *}
 
 <div class="context-block content-dashboard">
-    
+
 <div class="box-header">
     {include uri='design:dashboard/maintenance.tpl' }
 </div>

--- a/design/admin/templates/dashboard/maintenance.tpl
+++ b/design/admin/templates/dashboard/maintenance.tpl
@@ -1,7 +1,0 @@
-<div id="dashboard-logo"></div>
-<div id="mainteinance-text">
-    <h2>{'Software update and Maintenance'|i18n( 'design/admin/dashboard/maintenance' )}</h2>
-
-    <p>{'Your installation: <span id="ez-version">%1</span>'|i18n( 'design/admin/dashboard/maintenance', , array( fetch( 'setup', 'alias' ) ) )}</p>
-    <p>{'You are running <span class="edition-info">%edition</span>, it might not be up to date with the latest hot fixes and service packs. Contact <a href="%ez_link">eZ Systems</a> for more infomation.'|i18n( 'design/admin/dashboard/maintenance', , hash( '%edition', fetch( 'setup', 'edition' ), '%ez_link', "http://ez.no" ) )}</p>
-</div>

--- a/design/standard/templates/dashboard/maintenance.tpl
+++ b/design/standard/templates/dashboard/maintenance.tpl
@@ -1,6 +1,7 @@
 <h2>{'Software update and Maintenance'|i18n( 'design/admin/dashboard/maintenance' )}</h2>
 
 <p>{'Your installation: <span id="ez-version">%1</span>'|i18n( 'design/admin/dashboard/maintenance', , array( fetch( 'setup', 'version' ) ) )}</p>
-<p>{'You are using %edition, the <span id="ez-publish-community-project-is-innovative-and-cutting-edge">innovative and cutting-edge</span> version of eZ Publish, built by <a href="%ez_link">eZ Systems</a> and the <a href="%ez_community_link">eZ Community</a>.</p>
-<p>If this platform is critical for your business, we strongly recommend to subscribe to the Enterprise Edition of eZ Publish. More on <a href="%ez_link">eZ Systems</a>\' website.'|i18n( 'design/admin/dashboard/maintenance', , hash( '%edition', $edition, '%ez_link', "http://ez.no", '%ez_community_link', concat( 'http://share.ez.no?utm_content=eZ+Publish+Community+Project+', fetch( 'setup', 'version' ) , '&utm_source=eZ+Publish+Community+Project+Dashboard&utm_medium=eZ+Publish+Community+Project+Dashboard&utm_campaign=eZ+Publish+Community+Project+Dashboard' ) ) )}
+<p>
+	{'You are using a fork of eZ Publish build and maintained by'|i18n( 'design/admin/dashboard/maintenance' )}
+	<a href="https://www.mugo.ca">MugoWeb</a>.
 </p>

--- a/design/standard/templates/dashboard/maintenance.tpl
+++ b/design/standard/templates/dashboard/maintenance.tpl
@@ -2,6 +2,6 @@
 
 <p>{'Your installation: <span id="ez-version">%1</span>'|i18n( 'design/admin/dashboard/maintenance', , array( fetch( 'setup', 'version' ) ) )}</p>
 <p>
-	{'You are using a fork of eZ Publish build and maintained by'|i18n( 'design/admin/dashboard/maintenance' )}
+	{'You are using a fork of eZ Publish built and maintained by'|i18n( 'design/admin/dashboard/maintenance' )}
 	<a href="https://www.mugo.ca">MugoWeb</a>.
 </p>

--- a/settings/dashboard.ini
+++ b/settings/dashboard.ini
@@ -6,7 +6,7 @@ DashboardBlocks[]=pending_list
 DashboardBlocks[]=drafts
 DashboardBlocks[]=latest_content
 DashboardBlocks[]=all_latest_content
-DashboardBlocks[]=community_activity
+#DashboardBlocks[]=community_activity
 # DashboardBlocks[]=wishlist
 
 # [DashboardBlock_example]


### PR DESCRIPTION
Before
<img width="1046" alt="Screenshot 2021-01-07 at 12 30 40" src="https://user-images.githubusercontent.com/971684/103888499-24cbc900-50e5-11eb-94e7-03474683d156.png">

After (the typo "build/t" was fixed)
<img width="1045" alt="Screenshot 2021-01-07 at 12 29 13" src="https://user-images.githubusercontent.com/971684/103888528-301ef480-50e5-11eb-8bbe-7ca81fa93868.png">

