### PR TITLE
Not allowing user/register by default. You would need to explicitly add the policy to the anonymous role.

### DIFF
--- a/design/admin/templates/user/login.tpl
+++ b/design/admin/templates/user/login.tpl
@@ -1,3 +1,5 @@
+{def $allow_register_account = fetch( 'user', 'has_access_to', hash( 'module', 'user', 'function', 'register' ) )}
+
 {* Warnings *}
 {if $User:warning.bad_login}
 <div class="message-warning">
@@ -67,7 +69,7 @@
     <div class="login-input-wrapper">
         <input class="defaultbutton" type="submit" id="loginbutton" name="LoginButton" value="{'Log in'|i18n( 'design/admin/user/login', 'Login button' )}" tabindex="3" title="{'Click here to log in using the username/password combination entered in the fields above.'|i18n( 'design/admin/user/login' )}" />
     </div>
-    {if ezmodule( 'user/register' )}
+    {if and( ezmodule( 'user/register' ), $allow_register_account )}
         <div class="login-text-wrapper">
             {'or'|i18n( 'design/admin/user/login')}
             <br/>

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -840,7 +840,6 @@ EnableCaching=true
 PolicyOmitList[]
 PolicyOmitList[]=user/login
 PolicyOmitList[]=user/logout
-PolicyOmitList[]=user/register
 PolicyOmitList[]=user/activate
 PolicyOmitList[]=user/success
 PolicyOmitList[]=user/forgotpassword


### PR DESCRIPTION
By default, the user/register module/view is always enabled. Allowing everybody (including bots) to register ez publish accounts. If the policies are not configured correctly, it's possible to gain extra permissions creating that account.

This pull request is not allowing user/register by default. An admin user would need to explicitly give that policy to the anonymous role. The login screen is only showing the link to 'Register a new account' if the policy is available.

Background: I recognized a few strange (very cryptic username, first name, last name) user accounts on a eZ Publish site. It looks like a bot was creating those in order to try to get more access on a site.
