### PR TITLE
Removing the archive zeta component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "ext-intl": "*",
         "symfony/polyfill-php73":  "^1.9",
         "ezsystems/ezpublish-legacy-installer": "*",
-        "zetacomponents/archive": "~1.5",
         "zetacomponents/authentication": "~1.4",
         "zetacomponents/authentication-database-tiein": "~1.2",
         "zetacomponents/cache": "~1.6",

--- a/kernel/classes/ezpackage.php
+++ b/kernel/classes/ezpackage.php
@@ -1069,25 +1069,13 @@ class eZPackage
                 eZDir::copy( $dir, $destDir );
         }
 
-        $tarArchivePath = $temporaryExportPath . '/archive.tmp';
-        $tarArchive = ezcArchive::open( $tarArchivePath, ezcArchive::TAR_USTAR );
-        $tarArchive->truncate();
 
-        $prefix = $tempPath . '/';
-        $fileList = array();
-        eZDir::recursiveList( $tempPath, $tempPath, $fileList );
+        $tarArchivePath = $temporaryExportPath . '/' . pathinfo( $archivePath, PATHINFO_FILENAME ) . '.tar';
+        $tarArchive = new PharData( $tarArchivePath );
 
-        foreach ( $fileList as $fileInfo )
-        {
-            $path = $fileInfo['type'] === 'dir' ?
-                $fileInfo['path'] . '/' . $fileInfo['name'] . '/' :
-                $fileInfo['path'] . '/' . $fileInfo['name'];
-            $tarArchive->append( array( $path ), $prefix );
-        }
+        $tarArchive->buildFromDirectory( $tempPath );
 
-        $tarArchive->close();
-
-        copy( $tarArchivePath, "compress.zlib://$archivePath" );
+        $tarArchive->compress( Phar::GZ, 'ezpkg' );
 
         unlink( $tarArchivePath );
 

--- a/kernel/classes/ezpackage.php
+++ b/kernel/classes/ezpackage.php
@@ -1069,7 +1069,6 @@ class eZPackage
                 eZDir::copy( $dir, $destDir );
         }
 
-
         $tarArchivePath = $temporaryExportPath . '/' . pathinfo( $archivePath, PATHINFO_FILENAME ) . '.tar';
         $tarArchive = new PharData( $tarArchivePath );
 


### PR DESCRIPTION
Instead of using that unmaintained library, ezp now uses pure PHP functionality in order to build a tar.gz archive (.ezpkg).
