### PR TITLE
Replacing unsupported/dropped mysql function PASSWORD()

### DIFF
--- a/kernel/classes/datatypes/ezuser/eztextfileuser.php
+++ b/kernel/classes/datatypes/ezuser/eztextfileuser.php
@@ -62,11 +62,12 @@ class eZTextFileUser extends eZUser
         // if mysql
         if ( $databaseName === 'mysql' )
         {
+            $passwordHash = password_hash( $password, PASSWORD_DEFAULT  );
             $query = "SELECT contentobject_id, password_hash, password_hash_type, email, login
                       FROM ezuser, ezcontentobject
                       WHERE ( $loginText ) AND
                         ezcontentobject.status='$contentObjectStatus' AND
-                        ( ezcontentobject.id=contentobject_id OR ( password_hash_type=4 AND ( $loginText ) AND password_hash=PASSWORD('$passwordEscaped') ) )";
+                        ( ezcontentobject.id=contentobject_id OR ( password_hash_type=7 AND ( $loginText ) AND password_hash='$passwordHash' ) )";
         }
         else
         {


### PR DESCRIPTION
The mysql PASSWORD() function is no longer supported in mysql 8.x

There have been already pull requests to change the password hash in the DB. But the code in kernel/classes/datatypes/ezuser/eztextfileuser.php is an oversight. This pull request is hashing the password with the PHP function password_hash() and stores it together with the password_hash_type 7 in the DB.

The password_hash_type is the correct type for password hashes generated with the PHP function.
