### PR TITLE
Fix legacy bridge view cache clear on Ibexa 4.x

### DIFF
--- a/kernel/classes/ezcontentcachemanager.php
+++ b/kernel/classes/ezcontentcachemanager.php
@@ -770,7 +770,7 @@ class eZContentCacheManager
 
         if ( eZContentCache::inCleanupThresholdRange( $cleanupValue ) )
         {
-            $nodeList = ezpEvent::getInstance()->filter( 'content/cache', $nodeList, $contentObjectList );
+            ezpEvent::getInstance()->notify( 'content/cache', array( $nodeList, $contentObjectList ) );
             eZContentCache::cleanup( $nodeList );
         }
         else


### PR DESCRIPTION
Legacy cache clear function eZContentCacheManager::clearNodeViewCacheArray() triggers the "content/cache" event:

https://github.com/mugoweb/ezpublish-legacy/blob/master/kernel/classes/ezcontentcachemanager.php#L773

That event has a couple of functions attached to it, the first (and problematic one) being:

https://github.com/netgen/ibexa-legacy-bridge/blob/4.x/bundle/LegacyMapper/Configuration.php#L207

However, that function no longer returns a list of node IDs because it's a void function (which is a new requirement per the interface it implements):

https://github.com/netgen/ibexa-legacy-bridge/blob/4.x/bundle/Cache/SwitchableHttpCachePurger.php#L28

Here's the original version of the function that does return location IDs:

https://github.com/ezsystems/LegacyBridge/blob/master/bundle/Cache/SwitchableHttpCachePurger.php#L28

So by the time the event filter is returned, $nodeList is null.

However, we don't actually need the cache clear node list to be modifiable, so we can just notify any event listeners without looking for a return value.