### PR TITLE
Partial revert of patch for EZP-29723

### DIFF
--- a/kernel/content/attribute_edit.php
+++ b/kernel/content/attribute_edit.php
@@ -334,6 +334,10 @@ if ( $storingAllowed && $hasObjectInput)
     $db->begin();
     $object->setName( $class->contentObjectName( $object, $version->attribute( 'version' ), $EditLanguage ), $version->attribute( 'version' ), $EditLanguage );
     $db->commit();
+  
+    // While being fetched, attributes might have been modified.
+    // The list needs to be refreshed so it is accurately displayed.
+    $contentObjectAttributes = $version->contentObjectAttributes( $EditLanguage );
 }
 elseif ( $storingAllowed )
 {


### PR DESCRIPTION
Revert part of [mugoweb#130](https://github.com/mugoweb/ezpublish-legacy/pull/130)

Issues from the original patch:
* We have a custom datatype (from the mugo_calendar extension) whose data is empty after you save a draft (specifically, after removing an image).
* For a client, we have a custom edit handler whose content does not get saved with this code: `$contentObjectAttribute->fromString( $selectedNodes ); $contentObjectAttribute->store();`