### PR TITLE
Updated: Bugfix fatal error for content/copy via content/browse modul…

### DIFF
--- a/design/admin/templates/content/browse_mode_list.tpl
+++ b/design/admin/templates/content/browse_mode_list.tpl
@@ -1,5 +1,10 @@
 {if and( eq( $browse.action_name, 'SwapNode' ), is_set( $browse.persistent_data.ContentNodeID ) )}
     {def $swap_node = fetch( 'content', 'node', hash( 'node_id', $browse.persistent_data.ContentNodeID ) )}
+    {if is_null( $swap_node )|not}
+        {def $swap_node_class = get_class( $swap_node )}
+    {else}
+        {def $swap_node_class = false()}
+    {/if}
 {/if}
 
 <table class="list" cellspacing="0">
@@ -69,7 +74,7 @@
             {if and( or( eq( $browse.action_name, 'MoveNode' ), eq( $browse.action_name, 'CopyNode' ), eq( $browse.action_name, 'AddNodeAssignment' ) ), $Nodes.item.object.content_class.is_container|not )}
                 <input type="{$select_type}" name="{$select_name}[]" value="{$Nodes.item[$select_attribute]}" disabled="disabled" />
             {elseif and( eq( $browse.action_name, 'SwapNode' ),
-                         eq( get_class( $swap_node ), 'ezcontentobjecttreenode' ),
+                         eq( $swap_node_class, 'ezcontentobjecttreenode' ),
                          or( and( $swap_node.children_count|gt(0), $Nodes.item.object.content_class.is_container|not ),
                              and( $swap_node.is_container|not, $Nodes.item.children_count|gt(0) ) ) )}
                 <input type="{$select_type}" name="{$select_name}[]" value="{$Nodes.item[$select_attribute]}" disabled="disabled" />


### PR DESCRIPTION
…e views

Hello @pkamps,

I write today with another key ezp bug fix for 8.2 where this template logic causes a php fatal error when used. I have patched the template logic to simply avoid the fatal error by testing for the existence of a null variable.

I hope this gives lovestack ezpublish more concrete php8.2 support.

Cheers,
Brookins Consulting