### PR TITLE
Updated: Increase ZetaComponents console-tools and base version numbe…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "zetacomponents/authentication-database-tiein": "~1.2",
         "zetacomponents/cache": "~1.6",
         "zetacomponents/configuration": "~1.4",
-        "zetacomponents/console-tools": "~1.7",
+        "zetacomponents/console-tools": "^1.7.3",
         "zetacomponents/database": "~1.5",
         "zetacomponents/debug": "~1.3",
         "zetacomponents/event-log": "~1.5",
@@ -51,10 +51,11 @@
         "zetacomponents/persistent-object": "~1.8",
         "zetacomponents/signal-slot": "~1.2",
         "zetacomponents/system-information": "~1.1",
-        "zetacomponents/webdav": "~1.1"
+        "zetacomponents/webdav": "~1.1",
+        "zetacomponents/base": "^1.9.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.36",
+        "phpunit/phpunit": "^10.0.0",
         "zetacomponents/php-generator": "~1.1"
     },
     "autoload": {


### PR DESCRIPTION
…rs to include key php8 fixes

Hello @pkamps 

Today I write with another key zetacomponents and ezdebug log warnings bugfixes. This reduces the warnings to almost zero when properly installed.

We just want to include the latest bugfixes from the upstream zeta project so you have clean installs with empty debug logs on php8.2 and soon 8.3.

Thank you for your continued support!

Cheers,
Brookins Consulting