### PR TITLE
Update eZ logging to keep date, label, and message on the same line to improve readability

### DIFF
--- a/lib/ezutils/classes/ezdebug.php
+++ b/lib/ezutils/classes/ezdebug.php
@@ -770,7 +770,7 @@ class eZDebug
                 }
                 if ( $this->isLogFileEnabled( $verbosityLevel ) )
                 {
-                    $string = "$label:\n$string";
+                    $string = "$label: $string";
                     $this->writeFile( $fileName, $string, $verbosityLevel, $alwaysLog );
                 }
             }


### PR DESCRIPTION
More importantly helps when grep'ing logs by date/time as it keeps message and timestamp together.