### PR TITLE
7x contribution ezoe tel link support

### DIFF
--- a/extension/ezoe/design/standard/templates/ezoe/customattributes/link.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/customattributes/link.tpl
@@ -11,6 +11,7 @@
     <option value="http://">{'Http'|i18n('design/standard/ezoe')}</option>
     <option value="https://">{'Https'|i18n('design/standard/ezoe')}</option>
     <option value="mailto:">{'Mail'|i18n('design/standard/ezoe')}</option>
+    <option value="tel:">{'Tel'|i18n('design/standard/ezoe')}</option>
     <option value="#">{'Anchor'|i18n('design/standard/ezoe')}</option>
     <option value="">{'Other'|i18n('design/standard/ezoe')}</option>
 {/if}


### PR DESCRIPTION
Hello Mugo,

I wanted to share an improvement to ezoe that is supported without the change but we find our customers like the option to be displayed just the same in the link popup dialog drop down.

We have been using this change for some time and just recently included it in ezpublish 6 and thought that a change this small would also help the love stack edition of eZ publish.

Please let us know your thoughts. Thank you for your continued support!

I've tried to flaten this PR branch feel free to squash further.

Respectfully,
7x