### PR TITLE
Limit ezjscnode calls via the permission system

### DIFF
--- a/extension/ezjscore/settings/ezjscore.ini
+++ b/extension/ezjscore/settings/ezjscore.ini
@@ -78,6 +78,7 @@ CustomHosts[]
 [ezjscServer]
 # List of permission functions as used by the eZ Publish permission system
 FunctionList[]=ezjsctemplate
+FunctionList[]=ezjscnode
 #FunctionList[]=ezjsckeyword
 #FunctionList[]=ezjscrating_rate
 
@@ -115,6 +116,7 @@ Class=ezjscServerFunctionsJs
 # <root>/ezjscore/call/ezjscnode::subtree::2
 Class=ezjscServerFunctionsNode
 #File=extension/ezjscore/classes/ezjscserverfunctionsnode.php
+Functions[]=ezjscnode
 
 # Allows setting a Hard Limit to the subtree method to prevent the load of very large subtrees
 #  reducing server load and risk of DOS attacks.


### PR DESCRIPTION
Calls such as these:
* /ezjscore/call/ezjscnode::load::2?ContentType=xml
* /ezjscore/call/ezjscnode::subtree::2?ContentType=xml

... expose metadata on the front-end of your website. We should block these calls and require explicit permission via the permission system to access them.