### PR TITLE
Support PHP8

### DIFF
--- a/benchmarks/classes/ezbenchmarkclirunner.php
+++ b/benchmarks/classes/ezbenchmarkclirunner.php
@@ -45,7 +45,7 @@ class eZBenchmarkCLIRunner extends eZBenchmarkRunner
     /*!
      Displays the result text on the console.
     */
-    function display( $result )
+    function display($result, $repeatCount = 0)
     {
         $cli = eZCLI::instance();
         $col = 60;

--- a/kernel/classes/datatypes/ezisbn/ezisbn13.php
+++ b/kernel/classes/datatypes/ezisbn/ezisbn13.php
@@ -367,8 +367,8 @@ class eZISBN13
         $val = 0;
         for ( $i = 0; $i < self::LENGTH; $i++ )
         {
-            $val = $isbnNr{$i};
-            if ( !is_numeric( $isbnNr{$i} ) )
+            $val = $isbnNr[$i];
+            if ( !is_numeric( $isbnNr[$i] ) )
             {
                 $error = ezpI18n::tr( 'kernel/classes/datatypes', 'All ISBN 13 characters need to be numeric' );
                 return false;

--- a/kernel/classes/datatypes/ezuser/ezldapuser.php
+++ b/kernel/classes/datatypes/ezuser/ezldapuser.php
@@ -296,7 +296,12 @@ class eZLDAPUser extends eZUser
 
                 if( !$password )
                 {
-                    $password = crypt( microtime() );
+					//PHP 8 fix - change the method to genereate random password
+					//it is safe to change the hash method
+					//because this condition is about to genereate a random password to trigger eZUser::setFailedLoginAttempts
+                    //also, PHP doc encourages the use of password_hash to replace crypt() 
+                    //Ref: https://www.php.net/manual/en/function.crypt.php
+                    $password = password_hash( microtime(),  PASSWORD_DEFAULT );
                 }
 
                 // is it real authenticated LDAP user?

--- a/kernel/classes/ezcollaborationitem.php
+++ b/kernel/classes/ezcollaborationitem.php
@@ -333,7 +333,7 @@ class eZCollaborationItem extends eZPersistentObject
         return eZCollaborationItem::fetchListTool( $parameters, false );
     }
 
-    static function fetchListTool( $parameters = array(), $asCount )
+    static function fetchListTool( $parameters = array(), $asCount = true)
     {
         $parameters = array_merge( array( 'as_object' => true,
                                           'offset' => false,

--- a/kernel/classes/ezcollaborationitemstatus.php
+++ b/kernel/classes/ezcollaborationitemstatus.php
@@ -106,7 +106,7 @@ class eZCollaborationItemStatus extends eZPersistentObject
                                                                                    'is_read' => 1 ) );
     }
 
-    static function updateFields( $collaborationID, $userID = false, $fields )
+    static function updateFields( $collaborationID, $userID = false, $fields = array())
     {
         if ( $userID === false )
             $userID = eZUser::currentUserID();

--- a/kernel/classes/ezcontentbrowse.php
+++ b/kernel/classes/ezcontentbrowse.php
@@ -86,7 +86,7 @@ class eZContentBrowse
      Most data will be automatically derived from the \c action_name value taken from settings/browse.ini, other
      values will override default values.
     */
-    static function browse( $parameters = array(), &$module )
+    static function browse( $parameters = array(), &$module = null)
     {
         $ini = eZINI::instance( 'browse.ini' );
 

--- a/kernel/classes/ezcontentupload.php
+++ b/kernel/classes/ezcontentupload.php
@@ -107,7 +107,7 @@ class eZContentUpload
      Most data will be automatically derived from the \c action_name value taken from settings/upload.ini, other
      values will override default values.
     */
-    static function upload( $parameters = array(), $module )
+    static function upload( $parameters = array(), $module = null)
     {
         $ini = eZINI::instance( 'upload.ini' );
 

--- a/kernel/classes/ezorder.php
+++ b/kernel/classes/ezorder.php
@@ -219,7 +219,7 @@ class eZOrder extends eZPersistentObject
     /*!
      \return the active orders
     */
-    static function active( $asObject = true, $offset, $limit, $sortField = "created", $sortOrder = "asc", $show = eZOrder::SHOW_NORMAL )
+    static function active( $asObject = true, $offset = 0, $limit = 0, $sortField = "created", $sortOrder = "asc", $show = eZOrder::SHOW_NORMAL )
     {
         if ( $sortField == "user_name" )
         {

--- a/kernel/private/api/content/criteria_set.php
+++ b/kernel/private/api/content/criteria_set.php
@@ -21,7 +21,7 @@ class ezpContentCriteriaSet implements ArrayAccess, Countable, Iterator
      * @param mixed $offset
      * @param eZContentCriteria $value
      */
-    public function offsetSet( $offset, $value )
+    public function offsetSet( $offset, $value ): void
     {
         $this->criteria[] = $value;
     }
@@ -31,45 +31,51 @@ class ezpContentCriteriaSet implements ArrayAccess, Countable, Iterator
      *
      * @param mixed $offset
      */
-    public function offsetGet( $offset ){}
+    public function offsetGet( $offset ): mixed{
+        return $this->criteria[$offset];
+    }
 
-    public function offsetExists( $offset ){}
+    public function offsetExists( $offset ): bool {
+        return isset ($this->criteria[$offset]);
+    }
 
-    public function offsetUnset( $offset ){}
+    public function offsetUnset( $offset ): void{
+        unset( $this->criteria[$offset] );
+    }
 
     /**
      * Returns the number of registered criteria
      * @note Implements the count() method of the Countable interface
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count( $this->criteria );
     }
 
     //// Iterator interface
 
-    public function key()
+    public function key(): mixed
     {
         return  $this->pointer;
     }
 
-    public function current ()
+    public function current (): mixed
     {
         return $this->criteria[$this->pointer];
     }
 
-    public function next()
+    public function next(): void
     {
         ++$this->pointer;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->pointer = 0;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return isset( $this->criteria[$this->pointer] );
     }

--- a/kernel/private/api/content/field_set.php
+++ b/kernel/private/api/content/field_set.php
@@ -92,7 +92,7 @@ class ezpContentFieldSet implements ArrayAccess, Iterator
      *
      * @return ezpContentFieldSet
      */
-    public function offsetGet( $offset )
+    public function offsetGet( $offset ): mixed
     {
         // This needs to check if this language can be instanciated (e.g. is active on the installation)
         if ( !isset( $this->childrenFieldSets[$offset] ) )
@@ -183,7 +183,7 @@ class ezpContentFieldSet implements ArrayAccess, Iterator
     /**
      * Iterator::key()
      */
-    public function key()
+    public function key(): mixed
     {
         return current( $this->iteratorPointer );
     }
@@ -191,7 +191,7 @@ class ezpContentFieldSet implements ArrayAccess, Iterator
     /**
      * Iterator::current()
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->iteratorData[current( $this->iteratorPointer )];
     }
@@ -199,7 +199,7 @@ class ezpContentFieldSet implements ArrayAccess, Iterator
     /**
      * Iterator::next()
      */
-    public function next()
+    public function next(): void
     {
         next( $this->iteratorPointer );
     }
@@ -207,7 +207,7 @@ class ezpContentFieldSet implements ArrayAccess, Iterator
     /**
      * Iterator::rewind()
      */
-    public function rewind ()
+    public function rewind (): void
     {
         reset( $this->iteratorPointer );
     }
@@ -215,7 +215,7 @@ class ezpContentFieldSet implements ArrayAccess, Iterator
     /**
      * Iterator::valid()
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset( $this->iteratorData[current( $this->iteratorPointer )] );
     }

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs_filter_iterator.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs_filter_iterator.php
@@ -26,18 +26,20 @@ class eZDFSFileHandlerDFSBackendFilterIterator extends FilterIterator
 
     /**
      * Filters directories out
+     * return type ref: https://www.php.net/manual/en/filteriterator.accept.php
      */
-    public function accept()
+    public function accept(): bool
     {
         return $this->getInnerIterator()->current()->isFile();
     }
 
     /**
      * Transforms the SplFileInfo in a simple relative path
+     * return type ref: https://www.php.net/manual/en/filteriterator.current.php
      *
      * @return string The relative path to the current file
      */
-    public function current()
+    public function current(): mixed
     {
         /** @var SplFileInfo $file */
         $file = $this->getInnerIterator()->current();

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1296,7 +1296,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
      *
      * @return bool|array
      */
-    protected function _selectOne( $query, $fname, $error = false, $debug = false, $fetchCall )
+    protected function _selectOne( $query, $fname, $error = false, $debug = false, $fetchCall = null)
     {
         eZDebug::accumulatorStart( 'mysql_cluster_query', 'MySQL Cluster', 'DB queries' );
         $time = microtime( true );
@@ -1744,7 +1744,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
                 return false;
             }
             $generatingMetaData = mysqli_fetch_assoc( $res );
-            
+
             if ( empty( $generatingMetaData ) )
             {
                 eZDebug::writeError("An error occured while ending cache generation,  $generatingFilePath", $fname );

--- a/kernel/private/classes/ezautoloadgenerator.php
+++ b/kernel/private/classes/ezautoloadgenerator.php
@@ -410,7 +410,7 @@ class eZAutoloadGenerator
      * @param eZAutoloadGenerator $gen
      * @return array
      */
-    public static function findRecursive( $sourceDir, array $includeFilters = array(), array $excludeFilters = array(), eZAutoloadGenerator $gen )
+    public static function findRecursive( $sourceDir, array $includeFilters = array(), array $excludeFilters = array(), eZAutoloadGenerator $gen = null)
     {
         $gen->log( "Scanning for PHP-files." );
         $gen->startProgressOutput( self::OUTPUT_PROGRESS_PHASE1 );
@@ -451,7 +451,7 @@ class eZAutoloadGenerator
      *         not be opened for reading.
      * @return array
      */
-    static protected function walkRecursive( $sourceDir, array $includeFilters = array(), array $excludeFilters = array(), $callback, &$callbackContext )
+    static protected function walkRecursive( $sourceDir, array $includeFilters = array(), array $excludeFilters = array(), $callback = null, &$callbackContext = null)
     {
         if ( !is_dir( $sourceDir ) )
         {

--- a/kernel/private/classes/webdav/ezwebdavcontentbackend.php
+++ b/kernel/private/classes/webdav/ezwebdavcontentbackend.php
@@ -235,7 +235,7 @@ class eZWebDAVContentBackend extends ezcWebdavSimpleBackend implements ezcWebdav
             $source = $recurseCollections[$i];
 
             // add the slash at the end of the path if it is missing
-            if ( $source{strlen( $source ) - 1} !== '/' )
+            if ( $source[strlen( $source ) - 1] !== '/' )
             {
                 $source .= '/';
             }
@@ -1783,7 +1783,7 @@ class eZWebDAVContentBackend extends ezcWebdavSimpleBackend implements ezcWebdav
         // Always add the current collection
         $contentEntry = array();
         $scriptURL = $requestUri;
-        if ( $scriptURL{strlen( $scriptURL ) - 1} !== '/' )
+        if ( $scriptURL[strlen( $scriptURL ) - 1] !== '/' )
         {
             $scriptURL .= "/";
         }
@@ -1801,7 +1801,7 @@ class eZWebDAVContentBackend extends ezcWebdavSimpleBackend implements ezcWebdav
         if ( $depth > 0 )
         {
             $scriptURL = $requestUri;
-            if ( $scriptURL{strlen( $scriptURL ) - 1} !== '/' )
+            if ( $scriptURL[strlen( $scriptURL ) - 1] !== '/' )
             {
                 $scriptURL .= "/";
             }
@@ -1988,7 +1988,7 @@ class eZWebDAVContentBackend extends ezcWebdavSimpleBackend implements ezcWebdav
         $thisNodeInfo = $this->fetchNodeInfo( $fullPath, $node );
 
         $scriptURL = $fullPath;
-        if ( $scriptURL{strlen( $scriptURL ) - 1} !== '/' )
+        if ( $scriptURL[strlen( $scriptURL ) - 1] !== '/' )
         {
             $scriptURL .= "/";
         }
@@ -2029,7 +2029,7 @@ class eZWebDAVContentBackend extends ezcWebdavSimpleBackend implements ezcWebdav
 
         // add a slash at the end of the path, if it is missing
         $scriptURL = $target;
-        if ( $scriptURL{strlen( $scriptURL ) - 1} !== '/' )
+        if ( $scriptURL[strlen( $scriptURL ) - 1] !== '/' )
         {
             $scriptURL .= "/";
         }

--- a/kernel/private/modules/oauth/authorize.php
+++ b/kernel/private/modules/oauth/authorize.php
@@ -165,7 +165,7 @@ if ( $pResponseType == 'token')
     $parameters[] = 'access_token=' . urlencode( $rAccessToken );
     $parameters[] = 'refresh_token=' . urlencode( $rRefreshToken );
     $parameters[] = "expires_in=$rExpiresIn";
-    $location = "{$pRedirectUri}?" . implode( $parameters, '&' );
+    $location = "{$pRedirectUri}?" . implode('&', $parameters);
 
     response( '302 Found', $location );
 }
@@ -197,7 +197,7 @@ elseif ( $pResponseType ==  'code')
 
     $parameters[] = 'code=' . urlencode( $rCode );
     $parameters[] = "expires_in=$rExpiresIn";
-    $location = "{$pRedirectUri}?" . implode( $parameters, '&' );
+    $location = "{$pRedirectUri}?" . implode( '&', $parameters);
 
     response( '302 Found', $location );
 }

--- a/kernel/setup/ezsetuptests.php
+++ b/kernel/setup/ezsetuptests.php
@@ -256,7 +256,10 @@ function eZSetupCheckMagicQuotes( $type )
     if ( version_compare( PHP_VERSION, '7.4' ) >= 0 ) {
         $magicQuote = 0;
     } else {
-        $magicQuote = get_magic_quotes_gpc();
+        //php8 fix - get_magic_quotes_gpc() was removed in php8
+        // repalce it with false based on PHP doc "Always returns false. "
+        //https://www.php.net/manual/en/function.get-magic-quotes-gpc.php
+        $magicQuote = false;
     }
 
     $result = ( $magicQuote == 0 );

--- a/lib/ezdbschema/classes/ezpgsqlschema.php
+++ b/lib/ezdbschema/classes/ezpgsqlschema.php
@@ -395,7 +395,7 @@ class eZPgsqlSchema extends eZDBSchemaInterface
 
             case 'double precision':
                 return 'double';
-                
+
             case 'real':
                 return 'float';
 
@@ -542,7 +542,7 @@ class eZPgsqlSchema extends eZDBSchemaInterface
     /*!
      * \private
      */
-    function generateFieldDef( $table_name, $field_name, $def, $add_default_not_null = true, $params )
+    function generateFieldDef( $table_name, $field_name, $def, $add_default_not_null = true, $params = array())
     {
         $diffFriendly = isset( $params['diff_friendly'] ) ? $params['diff_friendly'] : false;
 

--- a/lib/ezpdf/classes/class.pdf.php
+++ b/lib/ezpdf/classes/class.pdf.php
@@ -3907,7 +3907,7 @@ class Cpdf
      *
      * @access private
      */
-    function addJpegImage_common( &$data, $x, $y, $w = 0, $h = 0, $imageWidth, $imageHeight, $channels = 3 )
+    function addJpegImage_common( &$data, $x, $y, $w = 0, $h = 0, $imageWidth = 0, $imageHeight = 0, $channels = 3 )
     {
         // note that this function is not to be called externally
         // it is just the common code between the GD and the file options

--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -316,7 +316,7 @@ class eZINI
      * @param string parameter parameter name
      * @return bool True if the the parameter is set.
      */
-    static function parameterSet( $fileName = 'site.ini', $rootDir = 'settings', &$section, &$parameter )
+    static function parameterSet( $fileName = 'site.ini', $rootDir = 'settings', &$section = null, &$parameter = null)
     {
         if ( !eZINI::exists( $fileName, $rootDir ) )
             return false;


### PR DESCRIPTION
Hi @pkamps,

I extracted the PHP8-related fix from one of Mugo's recent projects using PHP8.1.2.  

    PHP 8 fix - Fatal errors on incompatible method signatures
    PHP 8 fix - Passing the separator after the array is no longer supported.
    PHP 8 fix - crypt() function requires $salt parameter
    PHP 8 fix: Array and string offset access syntax with curly braces is no longer supported
    PHP 8 fix - Function get_magic_quotes_gpc was removed.
    PHP 8.1 Deprecate - Return types in PHP built-in class methods and deprecation notices.
    PHP 8.1 Deprecate - required parameters after optional parameters in function/method signatures