### PR TITLE
Update composer to support PHP versions 8.1 and up to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "mugoweb/ezfind": "^2020.04"
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.1 <=8.2",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
The PHP 8.1 is the version we have thoroughly tested. 