### PR TITLE
Dedicated error messaging for deprecated errors

### DIFF
--- a/lib/ezutils/classes/ezdebug.php
+++ b/lib/ezutils/classes/ezdebug.php
@@ -62,6 +62,7 @@ class eZDebug
     const LEVEL_TIMING_POINT = 4;
     const LEVEL_DEBUG = 5;
     const LEVEL_STRICT = 6;
+    const LEVEL_DEPRECATED = 7;
 
     const SHOW_NOTICE = 1; // 1 << (EZ_LEVEL_NOTICE - 1)
     const SHOW_WARNING = 2; // 1 << (EZ_LEVEL_WARNING - 1)
@@ -69,7 +70,8 @@ class eZDebug
     const SHOW_TIMING_POINT = 8; // 1 << (EZ_LEVEL_TIMING_POINT - 1)
     const SHOW_DEBUG = 16; // 1 << (EZ_LEVEL_DEBUG - 1)
     const SHOW_STRICT = 32; // 1 << (EZ_LEVEL_STRICT - 1)
-    const SHOW_ALL = 63; // EZ_SHOW_NOTICE | EZ_SHOW_WARNING | EZ_SHOW_ERROR | EZ_SHOW_TIMING_POINT | EZ_SHOW_DEBUG | EZ_SHOW_STRICT
+    const SHOW_DEPRECATED = 64;
+    const SHOW_ALL = 127; // EZ_SHOW_NOTICE | EZ_SHOW_WARNING | EZ_SHOW_ERROR | EZ_SHOW_TIMING_POINT | EZ_SHOW_DEBUG | EZ_SHOW_STRICT | SHOW_DEPRECATED
 
     const HANDLE_NONE = 0;
     const HANDLE_FROM_PHP = 1;
@@ -128,7 +130,10 @@ class eZDebug
                                  self::LEVEL_DEBUG => array( "var/log/",
                                                           "debug.log" ),
                                  self::LEVEL_STRICT => array( 'var/log/',
-                                                           'strict.log' ) );
+                                                           'strict.log' ),
+                                 self::LEVEL_DEPRECATED => array( 'var/log/',
+                                                           'deprecated.log' ),
+        );
         $this->MessageTypes = array( self::LEVEL_NOTICE,
                                      self::LEVEL_WARNING,
                                      self::LEVEL_ERROR,
@@ -146,13 +151,17 @@ class eZDebug
                                        self::LEVEL_ERROR => true,
                                        self::LEVEL_TIMING_POINT => true,
                                        self::LEVEL_DEBUG => true,
-                                       self::LEVEL_STRICT => true );
+                                       self::LEVEL_STRICT => true,
+                                       self::LEVEL_DEPRECATED => true,
+        );
         $this->AlwaysLog = array( self::LEVEL_NOTICE => false,
                                   self::LEVEL_WARNING => false,
                                   self::LEVEL_ERROR => true, // Error is on by default, due to its importance
                                   self::LEVEL_TIMING_POINT => false,
                                   self::LEVEL_DEBUG => false,
-                                  self::LEVEL_STRICT => false );
+                                  self::LEVEL_STRICT => false,
+                                  self::LEVEL_DEPRECATED => false,
+        );
         $this->GlobalLogFileEnabled = true;
         if ( isset( $GLOBALS['eZDebugLogFileEnabled'] ) )
         {
@@ -379,10 +388,14 @@ class eZDebug
             case 'E_CORE_WARNING':
             case 'E_COMPILE_WARNING':
             case 'E_USER_WARNING':
+            {
+                $this->writeWarning( $str, 'PHP: ' . $errname );
+            } break;
+
             case 'E_DEPRECATED':
             case 'E_USER_DEPRECATED':
             {
-                $this->writeWarning( $str, 'PHP: ' . $errname );
+                $this->writeDeprecated( $str, 'PHP: ' . $errname );
             } break;
 
             case 'E_NOTICE':
@@ -531,6 +544,55 @@ class eZDebug
         else
         {
             $debug->write( $string, self::LEVEL_WARNING, $label, $backgroundClass, $alwaysLog );
+        }
+    }
+
+    /**
+     * Deprecated used to be a warning in previous versions of ezp.
+     * But with the increased amount of Deprecated errors it was necessary
+     * to handle them separately otherwise the system is running out of memory.
+     * In PHP 8, there are a lot of potential deprecation error messages.
+     */
+    static function writeDeprecated( $string, $label = "", $backgroundClass = "" )
+    {
+        $alwaysLog = eZDebug::alwaysLogMessage( self::LEVEL_DEPRECATED );
+        $enabled = eZDebug::isDebugEnabled();
+        if ( !$alwaysLog and !$enabled )
+            return;
+
+        $show = eZDebug::showMessage( self::SHOW_DEPRECATED );
+        if ( !$alwaysLog and !$show )
+            return;
+
+        if ( is_object( $string ) || is_array( $string ) )
+            $string = eZDebug::dumpVariable( $string );
+
+        // Deprecated errors used to be warnings in ezp, that is why
+        // they are counted as "warning"
+        $GLOBALS['eZDebugWarning'] = true;
+        if ( !isset( $GLOBALS['eZDebugWarningCount'] ) )
+            $GLOBALS['eZDebugWarningCount'] = 0;
+        ++$GLOBALS['eZDebugWarningCount'];
+
+        $debug = eZDebug::instance();
+        if ( $debug->HandleType == self::HANDLE_TO_PHP )
+        {
+            // If we get here only because of $alwaysLog we should not trigger a PHP error
+            if ( $enabled and $show )
+            {
+                if ( $label )
+                    $string = "$label: $string";
+                trigger_error( $string, E_USER_DEPRECATED );
+            }
+        }
+        else
+        {
+            // Making sure we only log deprecated messages to the log file and not storing it
+            // for the ezdebug output due to memory limitations
+            $orgLogOnlyValue = (bool) eZDebug::isLogOnlyEnabled();
+            $GLOBALS['eZDebugLogOnly'] = true;
+            $debug->write( $string, self::LEVEL_DEPRECATED, $label, $backgroundClass, $alwaysLog );
+            $GLOBALS['eZDebugLogOnly'] = $orgLogOnlyValue;
         }
     }
 
@@ -724,6 +786,7 @@ class eZDebug
             case self::LEVEL_DEBUG:
             case self::LEVEL_TIMING_POINT:
             case self::LEVEL_STRICT:
+            case self::LEVEL_DEPRECATED:
                 break;
 
             default:

--- a/lib/ezutils/classes/ezdebug.php
+++ b/lib/ezutils/classes/ezdebug.php
@@ -189,7 +189,9 @@ class eZDebug
                                       self::LEVEL_WARNING => array(),
                                       self::LEVEL_ERROR => array(),
                                       self::LEVEL_DEBUG => array(),
-                                      self::LEVEL_STRICT => array() );
+                                      self::LEVEL_STRICT => array(),
+				      self::LEVEL_DEPRECATED => array(),
+        );
         $this->TimeAccumulatorList = array();
         $this->TimeAccumulatorGroupList = array();
         $this->topReportsList = array();

--- a/lib/ezutils/classes/ezdebug.php
+++ b/lib/ezutils/classes/ezdebug.php
@@ -95,7 +95,9 @@ class eZDebug
                                       self::LEVEL_WARNING => array(),
                                       self::LEVEL_ERROR => array(),
                                       self::LEVEL_DEBUG => array(),
-                                      self::LEVEL_STRICT => array() );
+                                      self::LEVEL_STRICT => array(),
+                                      self::LEVEL_DEPRECATED => array(),
+        );
 
         $this->OutputFormat = array( self::LEVEL_NOTICE => array( "color" => "green",
                                                                'style' => 'notice',


### PR DESCRIPTION
In a project, I run out of memory when the debug output is enabled. It happened after upgrading PHP to 8.x which causes the system to generate a lot more Deprecation errors.

The original ezp code is handling deprecation errors like warning errors. This pull request changes this and have a dedicated handling for deprecation errors. It will ignore them for the ezdebug output but it will still report them into a new dedicated log file.

That is fixing the memory issue I had in my ezp project.