### PR TITLE
Remove hardcoded sortBy to read its value either from ini or post var [#620]

### DIFF
--- a/extension/ezjscore/classes/ezjscserverfunctionsjs.php
+++ b/extension/ezjscore/classes/ezjscserverfunctionsjs.php
@@ -438,11 +438,25 @@ YUI( YUI3_config ).add('io-ez', function( Y )
         if ( self::hasPostValue( $http, 'EncodingDataMap' ) )
             $encodeParams['dataMap'] = $http->postVariable( 'EncodingDataMap' );
 
+        // set default sortBy value
+        $sortBy = array( 'published' => 'desc' );
+        $ezFindIni = eZINI::instance( "ezfind.ini" );
+        // check post variable
+        if ( self::hasPostValue( $http, 'SortByMethod' ) )
+        {
+            $sortBy = json_decode( $http->postVariable( 'SortByMethod' ), true );
+        }
+        // if empty/not defined, read the value from ezfind
+        else if ( $ezFindIni->BlockValues[ 'SearchSettings' ] )
+        {
+            $sortBy = $ezFindIni->variable( "SearchSettings", "SortBy" );
+        }
+
         // Prepare search parameters
         $params = array( 'SearchOffset' => $searchOffset,
                          'SearchLimit' => $searchLimit,
                          'SortArray' => array( 'published', 0 ), // Legacy search engine uses SortArray
-                         'SortBy' => array( 'published' => 'desc' ) // eZ Find search method implementation uses SortBy
+                         'SortBy' => $sortBy // eZ Find search method implementation uses SortBy
         );
 
         if ( self::hasPostValue( $http, 'SearchContentClassAttributeID' ) )

--- a/extension/ezjscore/classes/ezjscserverfunctionsjs.php
+++ b/extension/ezjscore/classes/ezjscserverfunctionsjs.php
@@ -441,13 +441,8 @@ YUI( YUI3_config ).add('io-ez', function( Y )
         // set default sortBy value
         $sortBy = array( 'published' => 'desc' );
         $ezFindIni = eZINI::instance( "ezfind.ini" );
-        // check post variable
-        if ( self::hasPostValue( $http, 'SortByMethod' ) )
-        {
-            $sortBy = json_decode( $http->postVariable( 'SortByMethod' ), true );
-        }
         // if empty/not defined, read the value from ezfind
-        else if ( $ezFindIni->BlockValues[ 'SearchSettings' ] )
+        if ( $ezFindIni->BlockValues[ 'SearchSettings' ] )
         {
             $sortBy = $ezFindIni->variable( "SearchSettings", "SortBy" );
         }

--- a/extension/ezjscore/settings/ezfind.ini.append.php
+++ b/extension/ezjscore/settings/ezfind.ini.append.php
@@ -1,0 +1,16 @@
+<?php /* #?ini charset="utf-8"?
+
+[SearchSettings]
+# The sort_by parameter is used to define the sort order of the search result.
+# To see what are the supported options visit the following url:
+# https://ezpublishdoc.mugo.ca/Extensions/eZ-Publish-extensions/eZ-Find/eZ-Find-2.1/Customization/Template-fetch-functions#Sort_by
+# SortBy key   = sort option. Possible values: [visit link above]
+# SortBy value = sort order. Possible values: [asc|desc]
+# It is also possible to specify multiple sort options through this variable.
+SortBy[]
+SortBy[published]=desc
+#SortBy[score]=desc
+#SortBy[author]=desc
+#SortBy[path]=desc
+
+*/ ?>


### PR DESCRIPTION
Hi @pkamps ,

I've removed the hardcoded sort by logic here:
extension/ezjscore/classes/ezjscserverfunctionsjs.php
to be able to read either a post variable or ini setting.

Now we can either use an ini setting to define the sort order we want to use globally or a new POST variable through the ajax call. Post variable will override the ini value (has higher priority)

The previous hardcoded value is now the default $sortBy value.

This PR needs to be combined with this one:
https://github.com/mugoweb/ezfind/pull/26


Let me know if you have any questions or you see something wrong in the code.

Thank you!

PS. This is the original ticket where this was implemented https://app.assembla.com/spaces/mugo-development-general/tickets/620