### PR TITLE
see #702: add support to samesite option for session cookies

### DIFF
--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -359,6 +359,7 @@ class eZSession
         }
         $path   = $ini->hasVariable( 'Session', 'CookiePath' )     ? $ini->variable( 'Session', 'CookiePath' )     : $params['path'];
         $domain = $ini->hasVariable( 'Session', 'CookieDomain' )   ? $ini->variable( 'Session', 'CookieDomain' )   : $params['domain'];
+        $samesite = $ini->hasVariable( 'Session', 'SameSite' ) ? $ini->variable( 'Session', 'SameSite' ) : 'None';
         if ( $ini->hasVariable( 'Session', 'CookieSecure' ) )
         {
             $secure = ( $ini->variable( 'Session', 'CookieSecure' ) == 'true' ) ? true : false ;
@@ -377,7 +378,14 @@ class eZSession
             {
                 $httponly = $params['httponly'];
             }
-            session_set_cookie_params( $lifetime, $path, $domain, $secure, $httponly );
+            session_set_cookie_params([
+                'lifetime' => $lifetime,
+                'path' => $path,
+                'domain' => $domain,
+                'secure' => $secure,
+                'httponly' => $httponly,
+                'samesite' => $samesite
+            ]);
         }
         else
         {

--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -359,7 +359,7 @@ class eZSession
         }
         $path   = $ini->hasVariable( 'Session', 'CookiePath' )     ? $ini->variable( 'Session', 'CookiePath' )     : $params['path'];
         $domain = $ini->hasVariable( 'Session', 'CookieDomain' )   ? $ini->variable( 'Session', 'CookieDomain' )   : $params['domain'];
-        $samesite = $ini->hasVariable( 'Session', 'SameSite' ) ? $ini->variable( 'Session', 'SameSite' ) : 'None';
+        $samesite = $ini->hasVariable( 'Session', 'SameSite' ) ? $ini->variable( 'Session', 'SameSite' ) : false;
         if ( $ini->hasVariable( 'Session', 'CookieSecure' ) )
         {
             $secure = ( $ini->variable( 'Session', 'CookieSecure' ) == 'true' ) ? true : false ;
@@ -378,14 +378,19 @@ class eZSession
             {
                 $httponly = $params['httponly'];
             }
-            session_set_cookie_params([
+            $cookieParameters =
+            [
                 'lifetime' => $lifetime,
                 'path' => $path,
                 'domain' => $domain,
                 'secure' => $secure,
                 'httponly' => $httponly,
-                'samesite' => $samesite
-            ]);
+            ];
+            if( $samesite )
+            {
+                $cookieParameters[ 'samesite' ] = $samesite;
+            }
+            session_set_cookie_params( $cookieParameters );
         }
         else
         {

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -216,7 +216,7 @@ SessionNamePerSiteAccess=enabled
 #CookieHttponly=false|true
 #  Tells browser if your cookie is restricted to a first-party or same-site context, only supported on php 7.3+
 #  No value means that NO SameSite cookie attribute will be set.
-#  'None' will sned the cookie for all requests, both same-site and cross-site.
+#  'None' will send the cookie for all requests, both same-site and cross-site.
 #  'Lax' will send the cookie for same-site and cross-site GET requests.
 #  'Strict' only same-site requests.
 #  - PHP setting: session.cookie_samesite

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -215,10 +215,12 @@ SessionNamePerSiteAccess=enabled
 #  - PHP setting: session.cookie_httponly
 #CookieHttponly=false|true
 #  Tells browser if your cookie is restricted to a first-party or same-site context, only supported on php 7.3+
-#  No value means that NO SameSite cookie attribute will be set
-#  Lax will send the cookie for cross-domain GET requests, while Strict will not.
+#  No value means that NO SameSite cookie attribute will be set.
+#  'None' will sned the cookie for all requests, both same-site and cross-site.
+#  'Lax' will send the cookie for same-site and cross-site GET requests.
+#  'Strict' only same-site requests.
 #  - PHP setting: session.cookie_samesite
-#SameSite=Lax|Strict
+#SameSite=None|Lax|Strict
 
 # Controls how baskets are cleaned up when session expires.
 # It can take on these values:

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -215,9 +215,10 @@ SessionNamePerSiteAccess=enabled
 #  - PHP setting: session.cookie_httponly
 #CookieHttponly=false|true
 #  Tells browser if your cookie is restricted to a first-party or same-site context, only supported on php 7.3+
-# Default value is 'None'.
+#  No value means that NO SameSite cookie attribute will be set
+#  Lax will send the cookie for cross-domain GET requests, while Strict will not.
 #  - PHP setting: session.cookie_samesite
-#SameSite=None|Lax|Strict
+#SameSite=Lax|Strict
 
 # Controls how baskets are cleaned up when session expires.
 # It can take on these values:

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -214,6 +214,10 @@ SessionNamePerSiteAccess=enabled
 #  Tells browser to not allow scripts to access cookie, only supported on php 5.2+
 #  - PHP setting: session.cookie_httponly
 #CookieHttponly=false|true
+#  Tells browser if your cookie is restricted to a first-party or same-site context, only supported on php 7.3+
+# Default value is 'None'.
+#  - PHP setting: session.cookie_samesite
+#SameSite=None|Lax|Strict
 
 # Controls how baskets are cleaned up when session expires.
 # It can take on these values:


### PR DESCRIPTION
Hi @pkamps ,

New feature to add support to the "samesite" session cookie option via INI setting.

Note that when using the session_set_cookie_params I also updated the approach to use the alternative signature of that function which uses an associative array instead of individual vars (supported on PHP 7.3+)
https://www.php.net/manual/en/function.session-set-cookie-params.php

Using the array makes it easy to set the "samesite" option.

This shouldn't not affect older instances using < 7.3 unless we pull these changes to that particular repo again. And for new projects, I don't see us using PHP < 7.3 so I think we should be fine.
In any case, if you like to add backwards compatibility then we could probably add an additional check with "phpversion()"?

### === TESTING NOTES ===
You can pull the changes on an existing lovestack instance you may have or use staging Habitat https://staging.habitatmag.com/habitat_admin (http auth: habitat/habitat) - full instance details [here](https://howto.mugo.ca/Howto/Clients/Habitat-Magazine-and-The-Habitat-Group)
1. Go to backend login and confirm the samesite attribute of the eZ session cookie shows "None". 
2. Confirm the login works.
3. Update the site.ini using the specific override you need, like for instance `settings/override/site.ini.append.staging.php` and add `SameSite=Lax` or `SameSite=Strict`
4. Remove all cookies and reload, confirm the new samesite value is in place.

Considerations.
* 'None' is the default value
* When using None, 'Secure' must be true. If you set on the site.ini `CookieSecure=false` and you are on https, the login should not work because cookies can't be stored.


Let me know what you think about this small session cookie enhancement. 

Thanks!