### PR TITLE
Fix Unexpected error, the message was : array_keys(): Argument #1 ($a…

### DIFF
--- a/lib/ezutils/classes/ezhttptool.php
+++ b/lib/ezutils/classes/ezhttptool.php
@@ -634,7 +634,7 @@ EOT;
 
     function createPostVarsFromImageButtons()
     {
-        foreach ( array_keys( $_POST ) as $key )
+        foreach ( array_keys( $_POST ?? [] ) as $key )
         {
             if ( substr( $key, -2 ) == '_x' )
             {


### PR DESCRIPTION
Add a default array as a fallback to prevent the error 
`Unexpected error, the message was : array_keys(): Argument #1 ($array) must be of type array, null given`

We encounter this error, which causes ezPaypal can't finish the transaction.